### PR TITLE
Make it possible to assign list/array item to specific variable in #each

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -42,9 +42,16 @@ var helpers = {
 
 		var resolved = resolve(items),
 			result = [],
+			asVariable,
+			aliases,
 			keys,
 			key,
 			i;
+
+		if (arguments.length === 3) {
+			asVariable = arguments[1];
+			options = arguments[2];
+		}
 
 		if( types.isListLike(resolved) ) {
 			return function(el){
@@ -57,11 +64,16 @@ var helpers = {
 				nodeLists.update(options.nodeList, [el]);
 
 				var cb = function (item, index, parentNodeList) {
+					var aliases = {
+						"%index": index,
+						"@index": index
+					};
 
-					return options.fn(options.scope.add({
-							"%index": index,
-							"@index": index
-						},{notContext: true}).add(item), options.options, parentNodeList);
+					if (asVariable) {
+						aliases[asVariable] = item;
+					}
+
+					return options.fn(options.scope.add(aliases,{notContext: true}).add(item), options.options, parentNodeList);
 
 				};
 				live.list(el, items, cb, options.context, el.parentNode, nodeList, function(list, parentNodeList){
@@ -74,10 +86,16 @@ var helpers = {
 
 		if ( !! expr && utils.isArrayLike(expr)) {
 			for (i = 0; i < expr.length; i++) {
-				result.push(options.fn(options.scope.add({
-						"%index": i,
-						"@index": i
-					},{notContext: true})
+				aliases = {
+					"%index": i,
+					"@index": i
+				};
+
+				if (asVariable) {
+					aliases[asVariable] = expr[i];
+				}
+
+				result.push(options.fn(options.scope.add(aliases,{notContext: true})
 					.add(expr[i])));
 			}
 		} else if (types.isMapLike(expr)) {
@@ -86,18 +104,30 @@ var helpers = {
 
 			for (i = 0; i < keys.length; i++) {
 				key = keys[i];
-				result.push(options.fn(options.scope.add({
-						"%key": key,
-						"@key": key
-					},{notContext: true})
+				aliases = {
+					"%key": key,
+					"@key": key
+				};
+
+				if (asVariable) {
+					aliases[asVariable] = expr[key];
+				}
+
+				result.push(options.fn(options.scope.add(aliases,{notContext: true})
 					.add(expr[key])));
 			}
 		} else if (expr instanceof Object) {
 			for (key in expr) {
-				result.push(options.fn(options.scope.add({
-						"%key": key,
-						"@key": key
-					},{notContext: true})
+				aliases = {
+					"%key": key,
+					"@key": key
+				};
+
+				if (asVariable) {
+					aliases[asVariable] = expr[key];
+				}
+
+				result.push(options.fn(options.scope.add(aliases,{notContext: true})
 					.add(expr[key])));
 			}
 

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -38,22 +38,28 @@ var resolveHash = function(hash){
 
 
 var helpers = {
-	"each": function(items, options){
+	"each": function(items) {
+		var args = [].slice.call(arguments),
+		    options = args.pop(),
+		    argsLen = args.length,
+		    argExprs = options.exprData.argExprs,
+		    resolved = resolve(items),
+		    asVariable,
+		    result = [],
+		    aliases,
+		    keys,
+		    key,
+		    i;
 
-		var resolved = resolve(items),
-			result = [],
-			asVariable,
-			aliases,
-			keys,
-			key,
-			i;
+		if (argsLen === 2 || (argsLen === 3 && argExprs[1].key === 'as')) {
+			asVariable = args[argsLen - 1];
 
-		if (arguments.length === 3) {
-			asVariable = arguments[1];
-			options = arguments[2];
+			if (typeof asVariable !== 'string') {
+				asVariable = argExprs[argsLen - 1].key;
+			}
 		}
 
-		if( types.isListLike(resolved) ) {
+		if (types.isListLike(resolved)) {
 			return function(el){
 				// make a child nodeList inside the can.view.live.html nodeList
 				// so that if the html is re
@@ -73,9 +79,9 @@ var helpers = {
 						aliases[asVariable] = item;
 					}
 
-					return options.fn(options.scope.add(aliases,{notContext: true}).add(item), options.options, parentNodeList);
-
+					return options.fn(options.scope.add(aliases, { notContext: true }).add(item), options.options, parentNodeList);
 				};
+
 				live.list(el, items, cb, options.context, el.parentNode, nodeList, function(list, parentNodeList){
 					return options.inverse(options.scope.add(list), options.options, parentNodeList);
 				});
@@ -95,8 +101,7 @@ var helpers = {
 					aliases[asVariable] = expr[i];
 				}
 
-				result.push(options.fn(options.scope.add(aliases,{notContext: true})
-					.add(expr[i])));
+				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(expr[i])));
 			}
 		} else if (types.isMapLike(expr)) {
 			keys = expr.constructor.keys(expr);
@@ -113,8 +118,7 @@ var helpers = {
 					aliases[asVariable] = expr[key];
 				}
 
-				result.push(options.fn(options.scope.add(aliases,{notContext: true})
-					.add(expr[key])));
+				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(expr[key])));
 			}
 		} else if (expr instanceof Object) {
 			for (key in expr) {
@@ -127,13 +131,11 @@ var helpers = {
 					aliases[asVariable] = expr[key];
 				}
 
-				result.push(options.fn(options.scope.add(aliases,{notContext: true})
-					.add(expr[key])));
+				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(expr[key])));
 			}
-
 		}
-		return result;
 
+		return result;
 	},
 	"@index": function(offset, options) {
 		if (!options) {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -4824,18 +4824,40 @@ function makeTest(name, doc, mutation) {
           equal(frag.firstChild.getAttribute("f"),"f", "able to set f");
 	});
 
-	test("Render with #each by assigning values to a specific variable", function () {
-		var animals = new CanList([{'name': 'sloth'}]),
-
-		template = "{{#each animals 'animal'}}" +
-		               "<span>{{animal.name}}</span>" +
-		           "{{/each}}";
-
+	test("Render with #each by assigning values to a specific variable wrapped in quotes", function () {
+		var template = "{{#each animals 'animal'}}" +
+		                   "<span>{{animal.name}}</span>" +
+		               "{{/each}}";
 		var renderer = stache(template);
+		var animals = new CanList([{ name: 'sloth' }]);
+		var frag = renderer({ animals: animals });
 		var div = doc.createElement('div');
-		var frag = renderer({
-			animals: animals
-		});
+
+		div.appendChild(frag);
+		equal(div.getElementsByTagName('span')[0].innerHTML, 'sloth');
+	});
+
+	test("Render with #each by assigning values to a specific variable without quotes", function () {
+		var template = "{{#each animals animal}}" +
+		                   "<span>{{animal.name}}</span>" +
+		               "{{/each}}";
+		var renderer = stache(template);
+		var animals = new CanList([{ name: 'sloth' }]);
+		var frag = renderer({ animals: animals });
+		var div = doc.createElement('div');
+
+		div.appendChild(frag);
+		equal(div.getElementsByTagName('span')[0].innerHTML, 'sloth');
+	});
+
+	test("Render with #each by assigning values to a specific variable and expressing it with `as` between list and value variable", function () {
+		var template = "{{#each animals as animal}}" +
+		                   "<span>{{animal.name}}</span>" +
+		               "{{/each}}";
+		var renderer = stache(template);
+		var animals = new CanList([{ name: 'sloth' }]);
+		var frag = renderer({ animals: animals });
+		var div = doc.createElement('div');
 
 		div.appendChild(frag);
 		equal(div.getElementsByTagName('span')[0].innerHTML, 'sloth');

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -4824,5 +4824,22 @@ function makeTest(name, doc, mutation) {
           equal(frag.firstChild.getAttribute("f"),"f", "able to set f");
 	});
 
+	test("Render with #each by assigning values to a specific variable", function () {
+		var animals = new CanList([{'name': 'sloth'}]),
+
+		template = "{{#each animals 'animal'}}" +
+		               "<span>{{animal.name}}</span>" +
+		           "{{/each}}";
+
+		var renderer = stache(template);
+		var div = doc.createElement('div');
+		var frag = renderer({
+			animals: animals
+		});
+
+		div.appendChild(frag);
+		equal(div.getElementsByTagName('span')[0].innerHTML, 'sloth');
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -2919,14 +2919,11 @@ function makeTest(name, doc, mutation) {
 		stop();
 		setTimeout(function(){
 			domMutate.removeChild.call(div, div.firstChild);
+			setTimeout(function () {
+				equal(data._bindings, 0, "there are no bindings");
+				start();
+			}, 30);
 		},10);
-		setTimeout(function () {
-
-			equal(data._bindings, 0, "there are no bindings");
-
-			start();
-		}, 30);
-
 	});
 
 	test("each directly within live html section", function () {


### PR DESCRIPTION
As discussed in here:
https://github.com/canjs/canjs/issues/2405

This makes it possible to do this:

```JavaScript
{{#each schools 'school'}}
    {{#each school.students 'student'}}
        <p>{{student.name}} is in school {{school.name}}</p>
    {{/each}}
{{/each}}
```

It doesn't fail any existing tests. I did copy and modify one of existing tests, but I didn't include it, because I'm not sure I would make it right. Also wanted to ship my code to you as fast as possible.