### PR TITLE
stache.registerConverter function

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -7,6 +7,7 @@ var HTMLSectionBuilder = require('./src/html_section');
 var TextSectionBuilder = require('./src/text_section');
 var mustacheCore = require('./src/mustache_core');
 var mustacheHelpers = require('../helpers/core');
+require('../helpers/converter');
 var getIntermediateAndImports = require('./src/intermediate_and_imports');
 
 var namespace = require('can-util/namespace');

--- a/docs/apis.json
+++ b/docs/apis.json
@@ -4,12 +4,14 @@
 			"can-stache.simpleHelper",
 			"can-stache.helper",
 			"can-stache.helperOptions",
+			"can-stache.getterSetter",
 			"can-stache.key",
 			"can-stache.sectionRenderer"
 		]},
 		{"static": [
 			"can-stache.registerHelper",
 			"can-stache.registerSimpleHelper",
+			"can-stache.registerConverter",
 			"can-stache.safeString"
 		]},
 		{"tags": [

--- a/docs/getterSetter.md
+++ b/docs/getterSetter.md
@@ -1,0 +1,39 @@
+@typedef {{get:can-stache.helper,set:function(*,can-compute...){}}} can-stache.getterSetter getterSetter
+@parent can-stache.types 
+
+@description The getterSetter argument passed to [can-stache.registerConverter registerConverter].
+
+@option {can-stache.helper} [get] Returns a Call expression value, fired any time any of the 
+passed in arguments take.  The function signature for `get` is one argument for each positional value
+in the Call, and one additional object for hash values iff hash values exist in the Call expression.
+
+Each argument is a compute if the argument has been marked with a tilde (`~`) prefix, otherwise the
+value of the argument is the same as the value of the corresponding scope property.
+
+
+@option {function(*,can-compute...){}} [set] Since the Call expression yields a [can-compute compute], its
+value could be changed by calling the compute.  An example of this is a two-way binding in the 
+`can-stache-bindings` plugin connecting an input value and a Scope property.  Using the set function, the
+properties that were passed into the Call expression can be updated to match the new value of the expression
+set by its compute.
+
+The first argument of `set()` is the value passed to the compute.  The remaining arguments are the same
+as for `get()`, with computes representing properties that have been marked with tildes (`~`) in the expression
+
+```js
+stache.registerConverter("isSelectedValue", {
+	get: function(item, selectedItemCompute, list) {
+	  // note that the list does not need to be computed, since it is listening
+	  //  to changes and the object is not completely replaced in the scope.
+	  var selectedItem = itemCompute();
+		return selectedItem  === item;
+	},
+	set: function(newItem, oldItem, selectedItemCompute, list) {
+		if(!~list.indexOf(newItem)) {
+			list.push(newItem);
+		}
+		selectedItemCompute(newItem);
+	}
+})
+
+```

--- a/docs/helpers/registerConverter.md
+++ b/docs/helpers/registerConverter.md
@@ -1,0 +1,33 @@
+@function can-stache.registerConverter
+@description Register a helper for bidirectional value conversion.
+@parent can-stache.static
+
+@signature `stache.registerConverter(name, getterSetter)`
+
+The following [can-stache.expressions Call expression]:
+
+```handlebars
+{{numberToString(~foo)}}
+```
+
+```js
+stache.registerConverter("numberToString", {
+  get: function(fooCompute) {
+  	return "" + fooCompute();
+  }, 
+  set: function(newVal, fooCompute) {
+  	fooCompute(+newVal);
+  }
+});
+```
+
+@param {String} name The name of the converter helper.
+@param {Object} getterSetter An object containing get() and set() functions
+
+@body
+
+Registers a conversion helper with the Mustache system.
+Pass the name of the helper followed by the get function, which fires
+when any of the argument values change, and a set function, which fires
+when the compute representing the value of this Call expression has its
+value set.

--- a/helpers/converter.js
+++ b/helpers/converter.js
@@ -1,0 +1,21 @@
+var helpers = require("./core");
+var expression = require("../src/expression");
+var makeArray = require("can-util/js/make-array/make-array")
+
+helpers.registerConverter = function(name, getterSetter) {
+	getterSetter = getterSetter || {};
+	helpers.registerHelper(name, function(newVal, source) {
+		var args = makeArray(arguments);
+		if(newVal instanceof expression.SetIdentifier) {
+			return typeof getterSetter.set === "function" 
+				? getterSetter.set.apply(this, [newVal.value].concat(args.slice(1))) 
+				: source(newVal.value);
+		} else {
+			return typeof getterSetter.get === "function" 
+				? getterSetter.get.apply(this, args)
+				: args[0];
+		}
+	});
+};
+
+module.exports = helpers;


### PR DESCRIPTION
registerConverter() is a wrapper around helpers used in a Call expression.  When it detects it's being called by a compute's setter, it calls the supplied set() function. Otherwise it calls get().