### PR TITLE
Dynamic Property Access

### DIFF
--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -107,6 +107,11 @@ var core = {
 			if(exprData.isHelper) {
 				return value;
 			}
+		} else if (exprData instanceof expression.Bracket) {
+			value = exprData.value(scope);
+			if(exprData.isHelper) {
+				return value;
+			}
 		} else {
 			var readOptions = {
 				// will return a function instead of calling it.
@@ -307,7 +312,7 @@ var core = {
 
 		// Pre-process the expression.
 		var exprData = core.expression.parse(expressionString);
-		if(!(exprData instanceof expression.Helper) && !(exprData instanceof expression.Call)) {
+		if(!(exprData instanceof expression.Helper) && !(exprData instanceof expression.Call) && !(exprData instanceof expression.Bracket)) {
 			exprData = new expression.Helper(exprData,[],{});
 		}
 		// A branching renderer takes truthy and falsey renderer.

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -382,3 +382,157 @@ test("registerConverter helpers are chainable", function () {
 	equal(data.attr("observeVal"), 127, 'push converter called');
 });
 
+test("expression.ast - [] operator", function(){
+	var ast = expression.ast("['propName']");
+
+	deepEqual(ast, {
+		type: "Bracket",
+		children: [{type: "Literal", value: "propName"}]
+	});
+
+	var ast2 = expression.ast("[propName]");
+
+	deepEqual(ast2, {
+		type: "Bracket",
+		children: [{type: "Lookup", key: "propName"}]
+	});
+
+	var ast3 = expression.ast("foo['bar']");
+
+	deepEqual(ast3, {
+		type: "Bracket",
+		root: {type: "Lookup", key: "foo"},
+		children: [{type: "Literal", value: "bar"}]
+	});
+
+	var ast3 = expression.ast("foo[bar]");
+
+	deepEqual(ast3, {
+		type: "Bracket",
+		root: {type: "Lookup", key: "foo"},
+		children: [{type: "Lookup", key: "bar"}]
+	});
+
+	var ast4 = expression.ast("foo()[bar]");
+
+	deepEqual(ast4, {
+		type: "Bracket",
+		root: {type: "Call", method: {key: "@foo", type: "Lookup" } },
+		children: [{type: "Lookup", key: "bar"}]
+	});
+});
+
+test("expression.parse - [] operator", function(){
+	var exprData = expression.parse("['propName']");
+	deepEqual(exprData,
+		new expression.Bracket(
+			new expression.Literal('propName')
+		)
+	);
+
+	exprData = expression.parse("[propName]");
+	deepEqual(exprData,
+		new expression.Bracket(
+			new expression.Lookup('propName')
+		)
+	);
+
+	exprData = expression.parse("foo['bar']");
+	deepEqual(exprData,
+		new expression.Bracket(
+			new expression.Literal('bar'),
+			new expression.Lookup('foo')
+		)
+	);
+
+	exprData = expression.parse("foo[bar]");
+	deepEqual(exprData,
+		new expression.Bracket(
+			new expression.Lookup('bar'),
+			new expression.Lookup('foo')
+		)
+	);
+
+	exprData = expression.parse("foo()[bar]");
+	deepEqual(exprData,
+		new expression.Bracket(
+			new expression.Lookup('bar'),
+			new expression.Call( new expression.Lookup('@foo'), [], {} )
+		)
+	);
+});
+
+test("Bracket expression", function(){
+	// ["bar"]
+	var expr = new expression.Bracket(
+		new expression.Literal("bar")
+	);
+	var compute = expr.value(
+		new Scope(
+			new CanMap({bar: "name"})
+		)
+	);
+	equal(compute(), "name");
+
+	// [bar]
+	expr = new expression.Bracket(
+		new expression.Lookup("bar")
+	);
+	var compute = expr.value(
+		new Scope(
+			new CanMap({bar: "name", name: "Kevin"})
+		)
+	);
+	equal(compute(), "Kevin");
+
+	// foo["bar"]
+	expr = new expression.Bracket(
+		new expression.Literal("bar"),
+		new expression.Lookup("foo")
+	);
+	var compute = expr.value(
+		new Scope(
+			new CanMap({foo: {bar: "name"}})
+		)
+	);
+	equal(compute(), "name");
+
+	// foo[bar]
+	expr = new expression.Bracket(
+		new expression.Lookup("bar"),
+		new expression.Lookup("foo")
+	);
+	var compute = expr.value(
+		new Scope(
+			new CanMap({foo: {name: "Kevin"}, bar: "name"})
+		)
+	);
+	equal(compute(), "Kevin");
+
+	// foo()[bar]
+	expr = new expression.Bracket(
+		new expression.Lookup("bar"),
+		new expression.Call( new expression.Lookup("@foo"), [], {} )
+	);
+	var compute = expr.value(
+		new Scope(
+			new CanMap({foo: function() { return {name: "Kevin"}; }, bar: "name"})
+		)
+	);
+	equal(compute(), "Kevin");
+
+	// foo()[bar()]
+	expr = new expression.Bracket(
+		new expression.Call( new expression.Lookup("@bar"), [], {} ),
+		new expression.Call( new expression.Lookup("@foo"), [], {} )
+	);
+	var compute = expr.value(
+		new Scope(
+			new CanMap({
+				foo: function() { return {name: "Kevin"}; },
+				bar: function () { return "name"; }
+			})
+		)
+	);
+	equal(compute(), "Kevin");
+});

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -4960,6 +4960,25 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal( lis[1].innerHTML, "2", "is 2");
 	});
 
+	test("Bracket expression", function () {
+		var template;
+		var div = doc.createElement('div');
+
+		template = stache("<p>{{ foo[bar] }}</p>");
+
+		var data = new CanMap({
+			bar: "name",
+			foo: {
+				name: "Kevin"
+			}
+		});
+		var dom = template(data);
+		div.appendChild(dom);
+		var p = div.getElementsByTagName('p');
+
+		equal(innerHTML(p[0]), 'Kevin', 'correct value for foo[bar]');
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
Closes https://github.com/canjs/can-stache/issues/7.

Handling property access in any of these forms:
`["bar"]`
`[bar]`
`foo["bar"]`
`foo[bar]`
`foo()[bar]`
`foo()[bar()]`