### PR TITLE
Hashes in Helper expressions should be looked up like Call expressions

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -645,11 +645,13 @@ var expression = {
 			//get all arguments and hashes
 			var hashes = {},
 				args = [],
-				children = ast.children;
+				children = ast.children,
+				ExpressionType = options.methodRule(ast);
 			if(children) {
 				for(var i = 0 ; i <children.length; i++) {
 					var child = children[i];
-					if(child.type === "Hashes" && ast.type === "Helper") {
+					if(child.type === "Hashes" && ast.type === "Helper" &&
+						!(ExpressionType === Call)) {
 
 						each(child.children, function(hash){
 							hashes[hash.prop] = this.hydrateAst( hash.children[0], options, ast.type, true );
@@ -662,7 +664,8 @@ var expression = {
 			}
 
 
-			return new (options.methodRule(ast))(this.hydrateAst(ast.method, options, ast.type), args, hashes);
+			return new ExpressionType(this.hydrateAst(ast.method, options, ast.type),
+																args, hashes);
 		} else if (ast.type === "Bracket") {
 			return new Bracket(
 				this.hydrateAst(ast.children[0], options),

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -178,6 +178,23 @@ test("expression.parse - everything", function(){
 	deepEqual( exprData, callHelperA, "full thing");
 });
 
+test("expression.parse(str, {lookupRule: 'method', methodRule: 'call'})",
+		 function(){
+
+	var exprData = expression.parse("withArgs content=content", {
+		lookupRule: "method",
+		methodRule: "call"
+	});
+
+	var valueContent = new expression.ScopeLookup("content");
+	var hashArg = new expression.Arg(new expression.Hashes({
+		content: valueContent
+	}));
+
+	equal(exprData.argExprs.length, 1, "there is one arg");
+	deepEqual(exprData.argExprs[0], hashArg, "correct hashes");
+});
+
 test("numeric expression.Literal", function(){
 	var exprData = expression.parse("3");
 


### PR DESCRIPTION
This changes makes it so that hashes within helpers work like call
expressions and are added to the arguments that are passed into the
helper function.