### PR TITLE
Fixed each helper to work inside attributes (#8)

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -65,7 +65,7 @@ var helpers = {
 			}
 		}
 
-		if (types.isListLike(resolved)) {
+		if (types.isListLike(resolved) && !options.stringOnly) {
 			return function(el){
 				// make a child nodeList inside the can.view.live.html nodeList
 				// so that if the html is re
@@ -97,17 +97,19 @@ var helpers = {
 		var expr = resolved;
 
 		if ( !! expr && utils.isArrayLike(expr)) {
-			for (i = 0; i < expr.length; i++) {
+			var isMapLike = types.isMapLike(expr);
+			for (i = 0; i < (isMapLike ? expr.attr('length') : expr.length); i++) {
 				aliases = {
 					"%index": i,
 					"@index": i
 				};
+				var item = isMapLike ? expr.attr(i) : expr[i];
 
 				if (asVariable) {
-					aliases[asVariable] = expr[i];
+					aliases[asVariable] = item;
 				}
 
-				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(expr[i])));
+				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(item)));
 			}
 		} else if (types.isMapLike(expr)) {
 			keys = expr.constructor.keys(expr);
@@ -141,7 +143,7 @@ var helpers = {
 			}
 		}
 
-		return result;
+		return !options.stringOnly ? result : result.join('');
 	},
 	"@index": function(offset, options) {
 		if (!options) {

--- a/src/expression.js
+++ b/src/expression.js
@@ -349,7 +349,8 @@ Helper.prototype.evaluator = function(helper, scope, helperOptions, /*REMOVE*/re
 
 	var helperOptionArg = {
 		fn: function () {},
-		inverse: function () {}
+		inverse: function () {},
+		stringOnly: stringOnly
 	},
 		context = scope.peak("."),
 		args = this.args(scope, helperOptions, nodeList, truthyRenderer, falseyRenderer, stringOnly),

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,5 +70,12 @@ module.exports = {
 		}
 		return observeObservables ?  convertedRenderer : Observation.ignore(convertedRenderer);
 	},
+	getItemsStringContent: function(items, isObserveList, helperOptions, options){
+		var txt = "";
+		for (var i = 0, len = isObserveList ? items.attr("length") : items.length; i < len; i++) {
+			txt += helperOptions.fn( isObserveList ? items.attr('' + i) : items[i], options);
+		}
+		return txt;
+	},
 	Options: Options
 };

--- a/test/stache-define-test.js
+++ b/test/stache-define-test.js
@@ -17,3 +17,21 @@ test("basic replacement and updating", function(){
 
 	equal( frag.firstChild.firstChild.nodeValue, "World","got back the right text");
 });
+
+
+test('Helper each inside a text section (attribute) (#8)', function(assert){
+	var template = stache('<div class="{{#each list}}{{.}} {{/}}"></div>');
+
+	var vm = new DefineMap({
+		list: new DefineList(['one','two'])
+	});
+	var frag = template(vm);
+	var className = frag.firstChild.className;
+
+	assert.equal( className, 'one two ' );
+
+	vm.list.push('three');
+	className = frag.firstChild.className;
+
+	assert.equal( className, 'one two three ' );
+});

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5011,6 +5011,23 @@ function makeTest(name, doc, mutation) {
 
 		assert.equal( className, 'sort-ascend');
 	});
+	
+	test('Helper each inside a text section (attribute) (#8)', function(assert){
+		var template = stache('<div class="{{#each list}}{{.}} {{/}}"></div>');
+
+		var vm = new CanMap({
+			list: new CanList(['one','two'])
+		});
+		var frag = template(vm);
+		var className = frag.firstChild.className;
+
+		assert.equal( className, 'one two ' );
+
+		vm.attr('list').push('three');
+		className = frag.firstChild.className;
+
+		assert.equal( className, 'one two three ' );
+	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 


### PR DESCRIPTION
Fixes:
```
<div class="{{#each list}} {{.}} {{/}}"></div>

<div class="1 2 3"></div>
```
Also works with `can.DefineList`.