### PR TITLE
{{#each}} works with iterables

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -12,6 +12,7 @@ var joinURIs = require('can-util/js/join-uris/join-uris');
 
 var each = require('can-util/js/each/each');
 var assign = require('can-util/js/assign/assign');
+var isIterable = require("can-util/js/is-iterable/is-iterable");
 
 
 var domData = require('can-util/dom/data/data');
@@ -111,7 +112,22 @@ var helpers = {
 
 				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(item)));
 			}
-		} else if (types.isMapLike(expr)) {
+		}
+		else if(isIterable(expr)) {
+			each(expr, function(value, key){
+				aliases = {
+					"%key": key
+				};
+
+				if (asVariable) {
+					aliases[asVariable] = value;
+				}
+
+				result.push(options.fn(options.scope.add(aliases, { notContext: true}).add(value)));
+
+			});
+		}
+		else if (types.isMapLike(expr)) {
 			keys = expr.constructor.keys(expr);
 			// listen to keys changing so we can livebind lists of attributes.
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "can-compute": "^3.0.0-pre.8",
     "can-observation": "^3.0.0-pre.7",
     "can-route": "^3.0.0-pre.13",
-    "can-util": "^3.0.0-pre.21",
+    "can-util": "^3.0.0-pre.35",
     "can-view-callbacks": "^3.0.0-pre.1",
     "can-view-live": "^3.0.0-pre.4",
     "can-view-nodelist": "^3.0.0-pre.3",
@@ -62,7 +62,7 @@
     "can-view-target": "^3.0.0-pre.1"
   },
   "devDependencies": {
-    "can-define": "^0.7.17",
+    "can-define": "^0.7.25",
     "can-event": "^3.0.0-pre.2",
     "can-list": "^3.0.0-pre.6",
     "can-map": "^3.0.0-pre.2",

--- a/test/stache-define-test.js
+++ b/test/stache-define-test.js
@@ -35,3 +35,34 @@ test('Helper each inside a text section (attribute) (#8)', function(assert){
 
 	assert.equal( className, 'one two three ' );
 });
+
+test("Using #each on a DefineMap", function(assert){
+	var template = stache("{{#each obj}}{{%key}}{{.}}{{/each}}");
+
+	var VM = DefineMap.extend({ 
+		seal: false
+	}, {
+		foo: "string",
+		bar: "string"
+	});
+
+	var vm = new VM({
+		foo: "bar",
+		bar: "foo"
+	});
+
+	vm.set("baz", "qux");
+
+	var frag = template({ obj: vm });
+
+	var first = frag.firstChild,
+		second = first.nextSibling.nextSibling,
+		third = second.nextSibling.nextSibling;
+
+	assert.equal(first.nodeValue, "foo");
+	assert.equal(first.nextSibling.nodeValue, "bar");
+	assert.equal(second.nodeValue, "bar");
+	assert.equal(second.nextSibling.nodeValue, "foo");
+	assert.equal(third.nodeValue, "baz");
+	assert.equal(third.nextSibling.nodeValue, "qux");
+});


### PR DESCRIPTION
This makes it so that {{#each}} works with iterable objects such as
DefineMaps and even regular JavaScript Maps.

Closes #55