### PR TITLE
Add a compute for listening to object changes in the `each` helper.

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -110,8 +110,7 @@ var helpers = {
 
 				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(item)));
 			}
-		}
-		else if(isIterable(expr)) {
+		} else if(isIterable(expr)) {
 			each(expr, function(value, key){
 				aliases = {
 					"%key": key
@@ -124,13 +123,13 @@ var helpers = {
 				result.push(options.fn(options.scope.add(aliases, { notContext: true}).add(value)));
 
 			});
-		}
-		else if (types.isMapLike(expr)) {
+		} else if (types.isMapLike(expr)) {
 			keys = expr.constructor.keys(expr);
-			// listen to keys changing so we can livebind lists of attributes.
 
+			// listen to keys changing so we can livebind lists of attributes.
 			for (i = 0; i < keys.length; i++) {
 				key = keys[i];
+                var value = compute(expr, key);
 				aliases = {
 					"%key": key,
 					"@key": key
@@ -139,8 +138,7 @@ var helpers = {
 				if (asVariable) {
 					aliases[asVariable] = expr[key];
 				}
-
-				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(expr[key])));
+				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(value)));
 			}
 		} else if (expr instanceof Object) {
 			for (key in expr) {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5118,6 +5118,20 @@ function makeTest(name, doc, mutation) {
 		equal(innerHTML(p[0]), 'Kevin Phillips', 'updated value for person().name');
 	});
 
+    test("each values update when replaced in a can map (#62)", function () {
+        var template = stache("{{#each this}}<p>{{.}}</p>{{/each}}");
+        var div = doc.createElement('div');
+        var vm = new CanMap({
+            foo: 'foo-value'
+        });
+        var dom = template(vm);
+        div.appendChild(dom);
+
+        vm.attr('foo', 'bar-value');
+        var p = div.getElementsByTagName('p');
+        equal(innerHTML(p[0]), 'bar-value', 'updated the value inside #each');
+    });
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
For #62 

Add a compute for listening to object changes in the `each` helper.