### PR TITLE
Making two-way binding in a bracket expression work when it has a root

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -53,9 +53,13 @@ var getKeyComputeData = function (key, scope, readOptions) {
 	lookupValueInResult = function(keyOrCompute, lookupOrCall, scope, helperOptions, readOptions) {
 		var result = lookupOrCall.value(scope, {}, {});
 
-		var c = compute(function() {
+		var c = compute(function(newVal) {
 			var key = getValueOfComputeOrFunction(keyOrCompute);
-			return observeReader.read(result, observeReader.reads(key)).value;
+			if (arguments.length) {
+				observeReader.write(result, observeReader.reads(key), newVal);
+			} else {
+				return observeReader.get(result, key);
+			}
 		});
 
 		return { value: c };

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -426,7 +426,7 @@ test("Bracket expression", function(){
 	expr = new expression.Bracket(
 		new expression.Lookup("bar")
 	);
-	var compute = expr.value(
+	compute = expr.value(
 		new Scope(
 			new CanMap({bar: "name", name: "Kevin"})
 		)
@@ -438,7 +438,7 @@ test("Bracket expression", function(){
 		new expression.Literal("bar"),
 		new expression.Lookup("foo")
 	);
-	var compute = expr.value(
+	compute = expr.value(
 		new Scope(
 			new CanMap({foo: {bar: "name"}})
 		)
@@ -450,12 +450,15 @@ test("Bracket expression", function(){
 		new expression.Lookup("bar"),
 		new expression.Lookup("foo")
 	);
-	var compute = expr.value(
+	var state = new CanMap({foo: {name: "Kevin"}, bar: "name"})
+	compute = expr.value(
 		new Scope(
-			new CanMap({foo: {name: "Kevin"}, bar: "name"})
+			state
 		)
 	);
 	equal(compute(), "Kevin");
+	compute("Curtis");
+	equal(state.attr("foo.name"), "Curtis");
 
 	// foo()[bar]
 	expr = new expression.Bracket(
@@ -466,7 +469,7 @@ test("Bracket expression", function(){
 			{}
 		)
 	);
-	var compute = expr.value(
+	compute = expr.value(
 		new Scope(
 			new CanMap({foo: function() { return {name: "Kevin"}; }, bar: "name"})
 		)


### PR DESCRIPTION
This makes sure that a bracket expression with a root like `{{foo[bar]}}` are two-way bound.

The compute that's created was only reading values (never writing) so two-way binding was broken.

Fixes #82 