### PR TITLE
Making bracket expression work in multi-arg helper

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -721,6 +721,8 @@ var expression = {
 				var firstParent = stack.first(["Helper", "Call", "Hash", "Bracket"]);
 				if(firstParent.type === "Hash" && (firstParent.children && firstParent.children.length > 0)) {
 					stack.addTo(["Helper", "Call", "Bracket"], {type: "Literal", value: utils.jsonParse( token )});
+				} else if(firstParent.type === "Bracket" && (firstParent.children && firstParent.children.length > 0)) {
+					stack.addTo(["Helper", "Call", "Hash"], {type: "Literal", value: utils.jsonParse( token )});
 				} else {
 					stack.addTo(["Helper", "Call", "Hash", "Bracket"], {type: "Literal", value: utils.jsonParse( token )});
 				}
@@ -768,6 +770,7 @@ var expression = {
 			// Lookup
 			else if(keyRegExp.test(token)) {
 				var lastToken = stack.topLastChild();
+				var firstParent = stack.first(["Helper", "Call", "Hash", "Bracket"]);
 
 				// if we had `foo().bar`, we need to change to a Lookup that looks up from lastToken.
 				if(lastToken && lastToken.type === "Call" && isAddingToExpression(token)) {
@@ -776,6 +779,10 @@ var expression = {
 						root: lastToken,
 						key: token.slice(1) // remove leading `.`
 					});
+				} else if(firstParent.type === 'Bracket' && !(firstParent.children && firstParent.children.length > 0)) {
+					stack.addToAndPush(["Bracket"], {type: "Lookup", key: token});
+				} else if(stack.first(["Helper", "Call", "Hash"]).type === 'Helper') {
+					stack.addToAndPush(["Helper"], {type: "Lookup", key: token});
 				} else {
 					// if two scopes, that means a helper
 					convertToHelperIfTopIsLookup(stack);

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -370,6 +370,40 @@ test("expression.ast - [] operator", function(){
 			children: [{type: "Lookup", key: "bar"}]
 		}]
 	});
+
+	deepEqual(expression.ast("eq foo['bar'] 'foo'"), {
+		type: "Helper",
+		method: {
+			type: "Lookup",
+			key: "eq"
+		},
+		children: [{
+			type: "Bracket",
+			root: {type: "Lookup", key: "foo"},
+			children: [{type: "Literal", value: "bar"}]
+		},
+		{
+			type: "Literal",
+			value: "foo"
+		}]
+	});
+
+	deepEqual(expression.ast("eq foo[bar] foo"), {
+		type: "Helper",
+		method: {
+			type: "Lookup",
+			key: "eq"
+		},
+		children: [{
+			type: "Bracket",
+			root: {type: "Lookup", key: "foo"},
+			children: [{type: "Lookup", key: "bar"}]
+		},
+		{
+			type: "Lookup",
+			key: "foo"
+		}]
+	});
 });
 
 test("expression.parse - [] operator", function(){

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5220,6 +5220,43 @@ function makeTest(name, doc, mutation) {
 		equal(innerHTML(div), 'bar', 'updated');
 	});
 
+	test("Bracket expression in multi-argument helpers (Literals)", function() {
+		var template = stache("{{#eq place['place:name'] 'foo' }}yes{{else}}no{{/eq}}");
+		var div = doc.createElement('div');
+		var vm = new CanMap({
+			place: {
+				'place:name': 'foo'
+			}
+		});
+		var dom = template(vm);
+		div.appendChild(dom);
+
+		equal(innerHTML(div), 'yes', 'initially true');
+
+		vm.attr('place.place:name', 'bar' );
+
+		equal(innerHTML(div), 'no', 'updated');
+	});
+
+	test("Bracket expression in multi-argument helpers (Lookups)", function() {
+		var template = stache("{{#eq place[foo] foo }}yes{{else}}no{{/eq}}");
+		var div = doc.createElement('div');
+		var vm = new CanMap({
+			place: {
+				'foo': 'foo'
+			},
+			foo: 'foo'
+		});
+		var dom = template(vm);
+		div.appendChild(dom);
+
+		equal(innerHTML(div), 'yes', 'initially true');
+
+		vm.attr('place.foo', 'bar' );
+
+		equal(innerHTML(div), 'no', 'updated');
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
This fixes the AST parser so using a bracket expression in a multi-argument helper works.

For example, `{{#eq place['foo'] 'bar}}`.

The fix was to make sure the first expression after the bracket's child (`'bar'`) was added to the argument list of the helper (`eq`) and not as another child of the bracket expression).