### PR TITLE
Mention can-stache-converters in the registerConverter docs

### DIFF
--- a/docs/registerConverter.md
+++ b/docs/registerConverter.md
@@ -1,5 +1,5 @@
 @function can-stache.registerConverter registerConverter
-@description Register a helper for bidirectional value conversion.
+@description Register a helper for bidirectional value conversion. Before creating your own converter, you may want to look at what’s provided by [can-stache-converters].
 @parent can-stache.static
 
 @signature `stache.registerConverter(converterName, getterSetter)`


### PR DESCRIPTION
I think this might help people not create converters that are [already in can-stache-converters](https://github.com/donejs/bitballs/pull/273#discussion_r88283445).