### PR TITLE
Handling expressions like foo[bar].baz

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -605,7 +605,7 @@ var expression = {
 		var tokens = [];
 		(expression.trim() + ' ').replace(tokensRegExp, function (whole, arg) {
 			if (bracketSpaceRegExp.test(arg)) {
-				tokens.push(arg.slice(0, 1));
+				tokens.push(arg[0]);
 				tokens.push(arg.slice(1));
 			} else {
 				tokens.push(arg);
@@ -796,14 +796,19 @@ var expression = {
 					});
 				}
 				else if(firstParent.type === 'Bracket') {
+					// a Bracket expression without children means we have
+					// parsed `foo[` of an expression like `foo[bar]`
+					// so we know to add the Lookup as a child of the Bracket expression
 					if (!(firstParent.children && firstParent.children.length > 0)) {
 						stack.addToAndPush(["Bracket"], {type: "Lookup", key: token});
 					} else {
-						// This is to make sure in a helper like `helper foo[bar] car` that
-						// car would not be added to the Bracket expression.
+						// This `=== 'Helper` check is to make sure expressions
+						// like `helper foo[bar] car` are parsed as helpers
+						// instead of like `helper foo[bar].car`
 						if(stack.first(["Helper", "Call", "Hash", "Arg"]).type === 'Helper') {
 							stack.addToAndPush(["Helper"], {type: "Lookup", key: token});
 						} else {
+							// This handles the `.baz` in expressions like `foo[bar].baz`
 							stack.replaceTopAndPush({
 								type: "Lookup",
 								key: token.slice(1),

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -29,7 +29,7 @@ test("expression.tokenize", function(){
 
 	var bracket = "[foo] bar [baz]";
 	res = expression.tokenize(bracket);
-	deepEqual(res, ["[", "foo", "]", "bar", " ", "[", "baz", "]"]);
+	deepEqual(res, ["[", "foo", "]", " ", "bar", " ", "[", "baz", "]", " "]);
 
 });
 
@@ -421,44 +421,51 @@ test("expression.ast - [] operator", function(){
 				children: [{type: "Lookup", key: "bar"}]
 		},
 		children: [{type: "Lookup", key: "baz"}]
-	},
-	"foo[bar][baz] valid"
-	);
+	}, "foo[bar][baz] valid");
+
+	deepEqual(expression.ast("foo[bar].baz"), {
+		type: "Lookup",
+		key: "baz",
+		root: {
+			type: "Bracket",
+			root: {type: "Lookup", key: "foo"},
+			children: [{type: "Lookup", key: "bar"}]
+		}
+	}, "foo[bar].baz");
 });
 
 test("expression.parse - [] operator", function(){
-	var exprData = expression.parse("['propName']");
-	deepEqual(exprData,
+	deepEqual(expression.parse("['propName']"),
 		new expression.Bracket(
 			new expression.Literal('propName')
-		)
+		),
+		"['propName']"
 	);
 
-	exprData = expression.parse("[propName]");
-	deepEqual(exprData,
+	deepEqual(expression.parse("[propName]"),
 		new expression.Bracket(
 			new expression.Lookup('propName')
-		)
+		),
+		"[propName]"
 	);
 
-	exprData = expression.parse("foo['bar']");
-	deepEqual(exprData,
+	deepEqual(expression.parse("foo['bar']"),
 		new expression.Bracket(
 			new expression.Literal('bar'),
 			new expression.Lookup('foo')
-		)
+		),
+		"foo['bar']"
 	);
 
-	exprData = expression.parse("foo[bar]");
-	deepEqual(exprData,
+	deepEqual(expression.parse("foo[bar]"),
 		new expression.Bracket(
 			new expression.Lookup('bar'),
 			new expression.Lookup('foo')
-		)
+		),
+		"foo[bar]"
 	);
 
-	exprData = expression.parse("foo()[bar]");
-	deepEqual(exprData,
+	deepEqual(expression.parse("foo()[bar]"),
 		new expression.Bracket(
 			new expression.Lookup('bar'),
 			new expression.Call(
@@ -466,7 +473,8 @@ test("expression.parse - [] operator", function(){
 				[],
 				{}
 			)
-		)
+		),
+		"foo()[bar]"
 	);
 
 	exprData = expression.parse("foo[bar()]");

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -432,6 +432,27 @@ test("expression.ast - [] operator", function(){
 			children: [{type: "Lookup", key: "bar"}]
 		}
 	}, "foo[bar].baz");
+
+	deepEqual(expression.ast("eq foo[bar].baz xyz"), {
+		type: "Helper",
+		method: {
+			type: "Lookup",
+			key: "eq"
+		},
+		children: [{
+			type: "Lookup",
+			key: "baz",
+			root: {
+				type: "Bracket",
+				root: {type: "Lookup", key: "foo"},
+				children: [{type: "Lookup", key: "bar"}]
+			}
+		},
+		{
+			type: "Lookup",
+			key: "xyz"
+		}]
+	}, "eq foo[bar].baz xyz");
 });
 
 test("expression.parse - [] operator", function(){

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5336,7 +5336,7 @@ function makeTest(name, doc, mutation) {
 		var template;
 		var div = doc.createElement('div');
 
-		template = stache("<p>{{ foo[bar].first }}</p>");
+		template = stache('<p>{{ foo[bar].first }}</p><p>{{#is foo[bar].first "K"}}short{{else}}long{{/is}}</p>');
 
 		var data = new CanMap({
 			baz: 'first',
@@ -5355,10 +5355,12 @@ function makeTest(name, doc, mutation) {
 		var p = div.getElementsByTagName('p');
 
 		equal(innerHTML(p[0]), 'K', 'correct value for foo[bar].first');
+		equal(innerHTML(p[1]), 'short', 'correct value for `is foo[bar].first "K"`');
 
 		data.attr('bar', 'fullName');
 
 		equal(innerHTML(p[0]), 'Kevin', 'updated value for foo[bar].first');
+		equal(innerHTML(p[1]), 'long', 'updated value for `is foo[bar].first "K"`');
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5332,6 +5332,34 @@ function makeTest(name, doc, mutation) {
 		equal(innerHTML(p[0]), 'thudjeek', 'correct value for bar[%index] when iterating foo (plain object data)');
 	});
 
+	test("Bracket expression followed by Lookup expression", function () {
+		var template;
+		var div = doc.createElement('div');
+
+		template = stache("<p>{{ foo[bar].first }}</p>");
+
+		var data = new CanMap({
+			baz: 'first',
+			bar: 'name',
+			foo: {
+				name: {
+					first: 'K'
+				},
+				fullName: {
+					first: 'Kevin'
+				}
+			}
+		});
+		var dom = template(data);
+		div.appendChild(dom);
+		var p = div.getElementsByTagName('p');
+
+		equal(innerHTML(p[0]), 'K', 'correct value for foo[bar].first');
+
+		data.attr('bar', 'fullName');
+
+		equal(innerHTML(p[0]), 'Kevin', 'updated value for foo[bar].first');
+	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 


### PR DESCRIPTION
This change makes it possible to use expressions like `foo[bar].baz`. In
order to make this work, the parser was updated to allow optional spaces
after `]` and then splitting the bracket and any spaces into separate
tokens in the `tokenize` function. This is needed in order do
differentiate `foo[bar].baz` from `foo[bar] baz` as in `eq foo[bar]
baz`. It is not possible to do this using regular expressions alone
because you cannot match a space only when it follows a `]` (regex in
JavaScript do not support look-behind).

Closes https://github.com/canjs/can-stache/issues/122.