### PR TITLE
Supports can-define in `#each`

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -51,9 +51,7 @@ var helpers = {
 			resolved = resolve(items),
 			asVariable,
 			aliases,
-			keys,
-			key,
-			i;
+			key;
 
 		if (argsLen === 2 || (argsLen === 3 && argExprs[1].key === 'as')) {
 			asVariable = args[argsLen - 1];
@@ -98,7 +96,8 @@ var helpers = {
 		if ( !! expr && utils.isArrayLike(expr)) {
 			result = utils.getItemsFragContent(expr, options, options.scope, asVariable);
 			return options.stringOnly ? result.join('') : result;
-		} else if(isIterable(expr)) {
+		}
+		else if(isIterable(expr)) {
 			result = [];
 			each(expr, function(value, key){
 				aliases = {
@@ -110,13 +109,11 @@ var helpers = {
 				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(value)));
 			});
 			return options.stringOnly ? result.join('') : result;
-		} else if (types.isMapLike(expr)) {
-			keys = expr.constructor.keys(expr);
+		}
+		else if (types.isMapLike(expr)) {
 			result = [];
 
-			// listen to keys changing so we can livebind lists of attributes.
-			for (i = 0; i < keys.length; i++) {
-				key = keys[i];
+			(expr.forEach || expr.each).call(expr, function(val, key){
 				var value = compute(expr, key);
 				aliases = {
 					"%key": key,
@@ -126,9 +123,11 @@ var helpers = {
 					aliases[asVariable] = expr[key];
 				}
 				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(value)));
-			}
+			});
+
 			return options.stringOnly ? result.join('') : result;
-		} else if (expr instanceof Object) {
+		}
+		else if (expr instanceof Object) {
 			result = [];
 			for (key in expr) {
 				aliases = {
@@ -214,7 +213,7 @@ var helpers = {
 		var logs = [];
 		each(arguments, function(val){
 			if(!looksLikeOptions(val)) {
-				logs.push(val)
+				logs.push(val);
 			}
 		});
 

--- a/test/stache-define-test.js
+++ b/test/stache-define-test.js
@@ -81,7 +81,7 @@ QUnit.test("{{%index}} and {{@index}} work with {{#key}} iteration", function ()
 	equal((span[3].innerHTML), '1', 'iteration for %index');
 });
 
-QUnit.test("iterate a DefineMap with {{#each}} (#125)", function(){
+QUnit.test("iterate a DefineMap with {{#each}} (#can-define/125)", function(){
 	var template = stache('<p>{{#each iter}}<span>{{%key}} {{.}}</span>{{/each}}</p>');
 	var div = document.createElement('div');
 

--- a/test/stache-define-test.js
+++ b/test/stache-define-test.js
@@ -39,7 +39,7 @@ test('Helper each inside a text section (attribute) (#8)', function(assert){
 test("Using #each on a DefineMap", function(assert){
 	var template = stache("{{#each obj}}{{%key}}{{.}}{{/each}}");
 
-	var VM = DefineMap.extend({ 
+	var VM = DefineMap.extend({
 		seal: false
 	}, {
 		foo: "string",
@@ -67,9 +67,9 @@ test("Using #each on a DefineMap", function(assert){
 	assert.equal(third.nextSibling.nodeValue, "qux");
 });
 
-test("{{%index}} and {{@index}} work with {{#key}} iteration", function () {
-	var template = stache('<p>{{#iter}}<span>{{@index}}</span>{{/iter}}</p> \
-	  					   <p>{{#iter}}<span>{{%index}}</span>{{/iter}}</p>');
+QUnit.test("{{%index}} and {{@index}} work with {{#key}} iteration", function () {
+	var template = stache('<p>{{#iter}}<span>{{@index}}</span>{{/iter}}</p> '+
+	  					   '<p>{{#iter}}<span>{{%index}}</span>{{/iter}}</p>');
 	var div = document.createElement('div');
 	var dom = template({iter: new DefineList(['hey', 'there'])});
 	div.appendChild(dom);
@@ -79,4 +79,16 @@ test("{{%index}} and {{@index}} work with {{#key}} iteration", function () {
 	equal((span[1].innerHTML), '1', 'iteration for %index');
 	equal((span[2].innerHTML), '0', 'iteration for %index');
 	equal((span[3].innerHTML), '1', 'iteration for %index');
+});
+
+QUnit.test("iterate a DefineMap with {{#each}} (#125)", function(){
+	var template = stache('<p>{{#each iter}}<span>{{%key}} {{.}}</span>{{/each}}</p>');
+	var div = document.createElement('div');
+
+	var dom = template({iter: new DefineMap({first: "justin", last: "meyer"})});
+	div.appendChild(dom);
+
+	var span = div.getElementsByTagName('span');
+	equal((span[0].innerHTML), 'first justin', 'first');
+	equal((span[1].innerHTML), 'last meyer', 'last');
 });


### PR DESCRIPTION
 Closes: https://github.com/canjs/can-define/issues/125