### PR TITLE
Allow numbers (literals and variables like %index) to be the value of bracket expressions.

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -57,7 +57,8 @@ var getKeyComputeData = function (key, scope, readOptions) {
 			if (arguments.length) {
 				observeReader.write(result, observeReader.reads(key), newVal);
 			} else {
-				return observeReader.get(result, key);
+				// Convert possibly numeric key to string, because observeReader.get will do a charAt test on it.
+				return observeReader.get(result, key.toString());
 			}
 		});
 
@@ -71,6 +72,10 @@ var getKeyComputeData = function (key, scope, readOptions) {
 
 		if (typeof computeOrFunction === 'function') {
 			return computeOrFunction();
+		}
+
+		if (computeOrFunction.computeData != null && computeOrFunction.hasOwnProperty("value")) {
+			return computeOrFunction.value;
 		}
 
 		return computeOrFunction;

--- a/src/expression.js
+++ b/src/expression.js
@@ -58,7 +58,7 @@ var getKeyComputeData = function (key, scope, readOptions) {
 				observeReader.write(result, observeReader.reads(key), newVal);
 			} else {
 				// Convert possibly numeric key to string, because observeReader.get will do a charAt test on it.
-				return observeReader.get(result, key.toString());
+				return observeReader.get(result, "" + key);
 			}
 		});
 

--- a/src/expression.js
+++ b/src/expression.js
@@ -74,10 +74,6 @@ var getKeyComputeData = function (key, scope, readOptions) {
 			return computeOrFunction();
 		}
 
-		if (computeOrFunction.computeData != null && computeOrFunction.hasOwnProperty("value")) {
-			return computeOrFunction.value;
-		}
-
 		return computeOrFunction;
 	},
 	// If not a Literal or an Arg, convert to an arg for caching.
@@ -108,6 +104,10 @@ Bracket.prototype.value = function (scope) {
 		prop = lookupValue(prop.key, scope, {}, {});
 	} else if (prop instanceof Call) {
 		prop = prop.value(scope, {}, {});
+	}
+
+	if (prop.computeData != null && prop.hasOwnProperty("value")) {
+		prop = prop.value;
 	}
 
 	if (!obj) {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5321,7 +5321,13 @@ function makeTest(name, doc, mutation) {
 		div.appendChild(dom);
 		p = div.getElementsByTagName('p');
 
-		equal(innerHTML(p[0]), 'thudjeek', 'correct value for bar[%index] when iterating foo');
+		equal(innerHTML(p[0]), 'thudjeek', 'correct value for bar[%index] when iterating foo (Map/List data)');
+
+		dom = template(data.attr());
+		div.appendChild(dom);
+		p = div.getElementsByTagName('p');
+
+		equal(innerHTML(p[0]), 'thudjeek', 'correct value for bar[%index] when iterating foo (plain object data)');
 	});
 
 

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5323,6 +5323,8 @@ function makeTest(name, doc, mutation) {
 
 		equal(innerHTML(p[0]), 'thudjeek', 'correct value for bar[%index] when iterating foo (Map/List data)');
 
+		div.innerHTML = '';
+
 		dom = template(data.attr());
 		div.appendChild(dom);
 		p = div.getElementsByTagName('p');

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5292,6 +5292,39 @@ function makeTest(name, doc, mutation) {
 		equal(innerHTML(p[0]), 'Phillips', 'updated value for baz in foo[bar][baz]');
 	});
 
+	test("Bracket expression with numeric index", function () {
+		var template, dom, p;
+		var div = doc.createElement('div');
+
+		template = stache("<p>{{ foo[0] }}</p>");
+
+		var data = new CanMap({
+			bar: [
+				'thud',
+				'jeek'
+			],
+			foo: [
+				'baz',
+				'quux'
+			]
+		});
+
+		dom = template(data);
+		div.appendChild(dom);
+		p = div.getElementsByTagName('p');
+		equal(innerHTML(p[0]), 'baz', 'correct value for foo[0]');
+
+		div.innerHTML = '';
+
+		template = stache("<p>{{#each foo}}{{ bar[%index] }}{{/each}}</p>")
+		dom = template(data);
+		div.appendChild(dom);
+		p = div.getElementsByTagName('p');
+
+		equal(innerHTML(p[0]), 'thudjeek', 'correct value for bar[%index] when iterating foo');
+	});
+
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
Currently staches with bracket expressions like: `{{#each foo}} {{ bar[%index] }} {{/each}}` cause an exception to be thrown from observe readers.  This fix provides for literal numbers and numeric variables to be used for bracket expressions.