### PR TITLE
Fix for Call expressions inside of Bracket expressions

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -468,6 +468,9 @@ assign(Stack.prototype,{
 	},
 	popTo: function(types){
 		this.popUntil(types);
+		this.pop();
+	},
+	pop: function() {
 		if(!this.isRootTop()) {
 			this.stack.pop();
 		}
@@ -782,7 +785,7 @@ var expression = {
 					});
 				}
 				else if(firstParent.type === 'Bracket' && !(firstParent.children && firstParent.children.length > 0)) {
-					stack.addTo(["Bracket"], {type: "Lookup", key: token});
+					stack.addToAndPush(["Bracket"], {type: "Lookup", key: token});
 				}
 				// This is to make sure in a helper like `helper foo[bar] car` that
 				// car would not be added to the Bracket expression.
@@ -803,6 +806,7 @@ var expression = {
 				stack.addToAndPush(["Helper", "Call", "Hash"], {type: "Arg", key: token});
 			}
 			// Call
+			// foo[bar()]
 			else if(token === "(") {
 				top = stack.top();
 				if(top.type === "Lookup") {
@@ -840,6 +844,10 @@ var expression = {
 				} else {
 					stack.replaceTopAndPush({type: "Bracket"});
 				}
+			}
+			// End Bracket
+			else if(token === "]") {
+				stack.pop();
 			}
 			else if(token === " ") {
 				stack.push(token);

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -353,6 +353,12 @@ test("expression.ast - [] operator", function(){
 	    children: [{type: "Lookup", key: "bar"}]
 	});
 
+	deepEqual(expression.ast("foo[bar()]"), {
+    type: "Bracket",
+		root: {type: "Lookup", key: "foo"},
+    children: [{type: "Call", method: {key: "@bar", type: "Lookup" }}]
+	});
+
 	deepEqual(expression.ast("foo()[bar]"), {
 		type: "Bracket",
 		root: {type: "Call", method: {key: "@foo", type: "Lookup" } },
@@ -386,7 +392,9 @@ test("expression.ast - [] operator", function(){
 			type: "Literal",
 			value: "foo"
 		}]
-	});
+	},
+	"eq foo['bar'] 'foo' valid"
+	);
 
 	deepEqual(expression.ast("eq foo[bar] foo"), {
 		type: "Helper",
@@ -413,7 +421,9 @@ test("expression.ast - [] operator", function(){
 				children: [{type: "Lookup", key: "bar"}]
 		},
 		children: [{type: "Lookup", key: "baz"}]
-	});
+	},
+	"foo[bar][baz] valid"
+	);
 });
 
 test("expression.parse - [] operator", function(){

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -334,36 +334,36 @@ test("expression.ast - [] operator", function(){
 	deepEqual(expression.ast("['propName']"), {
 		type: "Bracket",
 		children: [{type: "Literal", value: "propName"}]
-	});
+	}, "['propName'] valid");
 
 	deepEqual(expression.ast("[propName]"), {
     	type: "Bracket",
     	children: [{type: "Lookup", key: "propName"}]
-	});
+	}, "[propName] valid");
 
 	deepEqual(expression.ast("foo['bar']"), {
 	    type: "Bracket",
 			root: {type: "Lookup", key: "foo"},
 	    children: [{type: "Literal", value: "bar"}]
-	});
+	}, "foo['bar'] valid");
 
 	deepEqual(expression.ast("foo[bar]"), {
 	    type: "Bracket",
 			root: {type: "Lookup", key: "foo"},
 	    children: [{type: "Lookup", key: "bar"}]
-	});
+	}, "foo[bar] valid");
 
 	deepEqual(expression.ast("foo[bar()]"), {
     type: "Bracket",
 		root: {type: "Lookup", key: "foo"},
     children: [{type: "Call", method: {key: "@bar", type: "Lookup" }}]
-	});
+	}, "foo[bar()] valid");
 
 	deepEqual(expression.ast("foo()[bar]"), {
 		type: "Bracket",
 		root: {type: "Call", method: {key: "@foo", type: "Lookup" } },
 		children: [{type: "Lookup", key: "bar"}]
-	});
+	}, "foo()[bar] valid");
 
 	deepEqual(expression.ast("foo [bar]"), {
 		type: "Helper",
@@ -375,7 +375,7 @@ test("expression.ast - [] operator", function(){
 			type: "Bracket",
 			children: [{type: "Lookup", key: "bar"}]
 		}]
-	});
+	}, "foo [bar] valid");
 
 	deepEqual(expression.ast("eq foo['bar'] 'foo'"), {
 		type: "Helper",
@@ -411,7 +411,7 @@ test("expression.ast - [] operator", function(){
 			type: "Lookup",
 			key: "foo"
 		}]
-	});
+	}, "eq foo[bar] foo valid");
 
 	deepEqual(expression.ast("foo[bar][baz]"), {
 		type: "Bracket",
@@ -463,6 +463,34 @@ test("expression.parse - [] operator", function(){
 			new expression.Lookup('bar'),
 			new expression.Call(
 				new expression.Lookup('@foo'),
+				[],
+				{}
+			)
+		)
+	);
+
+	exprData = expression.parse("foo[bar()]");
+	deepEqual(exprData,
+		new expression.Bracket(
+			new expression.Call(
+				new expression.Lookup('@bar'),
+				[],
+				{}
+			),
+			new expression.Lookup('foo')
+		)
+	);
+
+	exprData = expression.parse("foo()[bar()]");
+	deepEqual(exprData,
+		new expression.Bracket(
+			new expression.Call(
+				new expression.Lookup("@bar"),
+				[],
+				{}
+			),
+			new expression.Call(
+				new expression.Lookup("@foo"),
 				[],
 				{}
 			)
@@ -532,6 +560,25 @@ test("Bracket expression", function(){
 	compute = expr.value(
 		new Scope(
 			new CanMap({foo: function() { return {name: "Kevin"}; }, bar: "name"})
+		)
+	);
+	equal(compute(), "Kevin");
+
+	// foo[bar()]
+	expr = new expression.Bracket(
+		new expression.Call(
+			new expression.Lookup('@bar'),
+			[],
+			{}
+		),
+		new expression.Lookup('foo')
+	);
+	compute = expr.value(
+		new Scope(
+			new CanMap({
+				foo: {name: "Kevin"},
+				bar: function () { return "name"; }
+			})
 		)
 	);
 	equal(compute(), "Kevin");


### PR DESCRIPTION
examples: `foo[bar()]` and `foo()[bar()]`
