### PR TITLE
remove @index and @key

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -73,8 +73,7 @@ var helpers = {
 
 				var cb = function (item, index, parentNodeList) {
 					var aliases = {
-						"%index": index,
-						"@index": index
+						"%index": index
 					};
 
 					if (asVariable) {
@@ -116,8 +115,7 @@ var helpers = {
 			(expr.forEach || expr.each).call(expr, function(val, key){
 				var value = compute(expr, key);
 				aliases = {
-					"%key": key,
-					"@key": key
+					"%key": key
 				};
 				if (asVariable) {
 					aliases[asVariable] = expr[key];
@@ -131,8 +129,7 @@ var helpers = {
 			result = [];
 			for (key in expr) {
 				aliases = {
-					"%key": key,
-					"@key": key
+					"%key": key
 				};
 				if (asVariable) {
 					aliases[asVariable] = expr[key];
@@ -142,12 +139,12 @@ var helpers = {
 			return options.stringOnly ? result.join('') : result;
 		}
 	},
-	"@index": function(offset, options) {
+	"%index": function(offset, options) {
 		if (!options) {
 			options = offset;
 			offset = 0;
 		}
-		var index = options.scope.peek("@index");
+		var index = options.scope.peek("%index");
 		return ""+((isFunction(index) ? index() : index) + offset);
 	},
 	'if': function (expr, options) {

--- a/readme.md
+++ b/readme.md
@@ -32,10 +32,10 @@ Live binding handlebars templates
       - <code>[{{#helper}}BLOCK{{else}}INVERSE{{/helper}}](#helperblockelseinversehelper)</code>
       - <code>[{{helper [args...] [hashProperty=hashValue...]}}](#helper-args-hashpropertyhashvalue)</code>
       - <code>[{{#if key}}BLOCK{{/if}}](#if-keyblockif)</code>
-      - <code>[{{@index [offset]}}](#index-offset)</code>
+      - <code>[{{%index [offset]}}](#index-offset)</code>
       - <code>[{{#is expr...}}BLOCK{{/is}}](#is-exprblockis)</code>
       - <code>[{{joinBase expr}}](#joinbase-expr)</code>
-      - <code>[{{@key}}](#key)</code>
+      - <code>[{{%key}}](#key)</code>
       - <code>[{{#log [message]}}](#log-message)</code>
       - <code>[{{#routeCurrent hashes}}SUBEXPRESSION{{/routeCurrent}}](#routecurrent-hashessubexpressionroutecurrent)</code>
       - <code>[routeCurrent([hashes])](#routecurrenthashes)</code>
@@ -649,7 +649,7 @@ Renders the `BLOCK` template within the current template.
   current context and its value is returned; otherwise, an empty string.
   
 
-#### <code>{{@index [offset]}}</code>
+#### <code>{{%index [offset]}}</code>
 
 
 Insert the index of an Array or [can-list] we are iterating on with [#each](can-stache.helpers.each)
@@ -692,7 +692,7 @@ Return an application-relative url for a resource.
   An application-relative url.
   
 
-#### <code>{{@key}}</code>
+#### <code>{{%key}}</code>
 
 
 Insert the property name of an Object or attribute name of a can.Map that we iterate over with [#each](can.stache.helpers.each)

--- a/src/expression.js
+++ b/src/expression.js
@@ -40,7 +40,9 @@ var getKeyComputeData = function (key, scope, readOptions) {
 		// If it doesn't look like a helper and there is no value, check helpers
 		// anyway. This is for when foo is a helper in `{{foo}}`.
 		if( res.computeData.initialValue === undefined ) {
-			if(key.charAt(0) === "@" && key !== "@index") {
+			// this check is for stache-converters
+			// a converter will use the @at-Key-Operator to get the function
+			if(key.charAt(0) === "@") {
 				key = key.substr(1);
 			}
 			var helper = mustacheHelpers.getHelper(key, helperOptions);

--- a/src/utils.js
+++ b/src/utils.js
@@ -93,8 +93,7 @@ module.exports = {
 
 		for (var i = 0; i < len; i++) {
 			var aliases = {
-				"%index": i,
-				"@index": i
+				"%index": i
 			};
 			var item = isObservable ? compute(items, '' + i) :items[i];
 

--- a/test/stache-define-test.js
+++ b/test/stache-define-test.js
@@ -67,18 +67,15 @@ test("Using #each on a DefineMap", function(assert){
 	assert.equal(third.nextSibling.nodeValue, "qux");
 });
 
-QUnit.test("{{%index}} and {{@index}} work with {{#key}} iteration", function () {
-	var template = stache('<p>{{#iter}}<span>{{@index}}</span>{{/iter}}</p> '+
-	  					   '<p>{{#iter}}<span>{{%index}}</span>{{/iter}}</p>');
+QUnit.test("{{%index}} work with {{#key}} iteration", function () {
+	var template = stache('<p>{{#iter}}<span>{{%index}}</span>{{/iter}}</p>');
 	var div = document.createElement('div');
 	var dom = template({iter: new DefineList(['hey', 'there'])});
 	div.appendChild(dom);
 
 	var span = div.getElementsByTagName('span');
-	equal((span[0].innerHTML), '0', 'iteration for @index');
+	equal((span[0].innerHTML), '0', 'iteration for %index');
 	equal((span[1].innerHTML), '1', 'iteration for %index');
-	equal((span[2].innerHTML), '0', 'iteration for %index');
-	equal((span[3].innerHTML), '1', 'iteration for %index');
 });
 
 QUnit.test("iterate a DefineMap with {{#each}} (#can-define/125)", function(){

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -2717,9 +2717,8 @@ function makeTest(name, doc, mutation) {
 
 	});
 
-	// TODO: duplicate with %
-	test("Rendering indicies of an array with @index", function () {
-		var template = stache("<ul>{{#each list}}<li>{{@index}} {{.}}</li>{{/each}}</ul>");
+	test("Rendering indicies of an array with %index", function () {
+		var template = stache("<ul>{{#each list}}<li>{{%index}} {{.}}</li>{{/each}}</ul>");
 		var list = [0, 1, 2, 3];
 
 		var lis = template({
@@ -2731,9 +2730,9 @@ function makeTest(name, doc, mutation) {
 			equal(innerHTML(lis[i]), (i + ' ' + i), 'rendered index and value are correct');
 		}
 	});
-	// TODO: duplicate with %
-	test("Rendering indicies of an array with @index + offset (#1078)", function () {
-		var template = stache("<ul>{{#each list}}<li>{{@index 5}} {{.}}</li>{{/each}}</ul>");
+
+	test("Rendering indicies of an array with %index + offset (#1078)", function () {
+		var template = stache("<ul>{{#each list}}<li>{{%index 5}} {{.}}</li>{{/each}}</ul>");
 		var list = [0, 1, 2, 3];
 
 		var lis = template({
@@ -2746,9 +2745,8 @@ function makeTest(name, doc, mutation) {
 		}
 	});
 
-	// TODO: duplicate with %
 	test("Passing indices into helpers as values", function () {
-		var template = stache("<ul>{{#each list}}<li>{{test @index}} {{.}}</li>{{/each}}</ul>");
+		var template = stache("<ul>{{#each list}}<li>{{test %index}} {{.}}</li>{{/each}}</ul>");
 		var list = [0, 1, 2, 3];
 
 		var lis = template({
@@ -2764,10 +2762,9 @@ function makeTest(name, doc, mutation) {
 		}
 	});
 
-	// TODO: duplicate with %
-	test("Rendering live bound indicies with #each, @index and a simple CanList", function () {
+	test("Rendering live bound indicies with #each, %index and a simple CanList", function () {
 		var list = new CanList(['a', 'b', 'c']);
-		var template = stache("<ul>{{#each list}}<li>{{@index}} {{.}}</li>{{/each}}</ul>");
+		var template = stache("<ul>{{#each list}}<li>{{%index}} {{.}}</li>{{/each}}</ul>");
 
 		var tpl = template({
 			list: list
@@ -2811,8 +2808,8 @@ function makeTest(name, doc, mutation) {
 		equal(innerHTML(lis[2]), '2 e', "fifth item now the 3rd item");
 	});
 
-	test('Rendering keys of an object with #each and @key', function () {
-		var template = stache("<ul>{{#each obj}}<li>{{@key}} {{.}}</li>{{/each}}</ul>");
+	test('Rendering keys of an object with #each and %key', function () {
+		var template = stache("<ul>{{#each obj}}<li>{{%key}} {{.}}</li>{{/each}}</ul>");
 		var obj = {
 			foo: 'string',
 			bar: 1,
@@ -2831,9 +2828,9 @@ function makeTest(name, doc, mutation) {
 		equal(innerHTML(lis[2]), 'baz false', "third key value pair rendered");
 	});
 
-	test('Live bound iteration of keys of a CanMap with #each and @key', function () {
+	test('Live bound iteration of keys of a CanMap with #each and %key', function () {
 		// delete stache._helpers.foo;
-		var template = stache("<ul>{{#each map}}<li>{{@key}} {{.}}</li>{{/each}}</ul>");
+		var template = stache("<ul>{{#each map}}<li>{{%key}} {{.}}</li>{{/each}}</ul>");
 		var map = new CanMap({
 			foo: 'string',
 			bar: 1,
@@ -2951,9 +2948,9 @@ function makeTest(name, doc, mutation) {
 
 	});
 
-	test('@index is correctly calculated when there are identical elements in the array', function () {
+	test('%index is correctly calculated when there are identical elements in the array', function () {
 		var data = new CanList(['foo', 'bar', 'baz', 'qux', 'foo']);
-		var tmp = stache('{{#each data}}{{@index}} {{/each}}');
+		var tmp = stache('{{#each data}}{{%index}} {{/each}}');
 
 		var div = doc.createElement('div');
 		var frag = tmp({
@@ -2996,9 +2993,9 @@ function makeTest(name, doc, mutation) {
 		});
 	});
 
-	test("Rendering live bound indicies with #each, @index and a simple CanList when remove first item (#613)", function () {
+	test("Rendering live bound indicies with #each, %index and a simple CanList when remove first item (#613)", function () {
 		var list = new CanList(['a', 'b', 'c']);
-		var template = stache("<ul>{{#each list}}<li>{{@index}} {{.}}</li>{{/each}}</ul>");
+		var template = stache("<ul>{{#each list}}<li>{{%index}} {{.}}</li>{{/each}}</ul>");
 
 		var tpl = template({
 			list: list
@@ -3135,11 +3132,11 @@ function makeTest(name, doc, mutation) {
 
 	});
 
-	test('Rendering keys of an object with #each and @key in a Component', function () {
+	test('Rendering keys of an object with #each and %key in a Component', function () {
 
 		var template = stache("<ul>" +
 		"{{#each data}}" +
-		"<li>{{@key}} : {{.}}</li>" +
+		"<li>{{%key}} : {{.}}</li>" +
 		"{{/data}}" +
 		"</ul>");
 
@@ -3369,7 +3366,7 @@ function makeTest(name, doc, mutation) {
 		}, 10);
 	});
 
-	test("@index in partials loaded from script templates", function () {
+	test("%index in partials loaded from script templates", function () {
 
 		if (doc === window.document) {
 			// add template as script
@@ -4535,7 +4532,7 @@ function makeTest(name, doc, mutation) {
 
 	});
 
-	test("Rendering live bound indicies with #each, @index and a simple CanList (#2067)", function () {
+	test("Rendering live bound indicies with #each, %index and a simple CanList (#2067)", function () {
 		var list = new CanList([{value:'a'}, {value:'b'}, {value: 'c'}]);
 		var template = stache("<ul>{{#each list}}<li>{{%index}} {{value}}</li>{{/each}}</ul>");
 
@@ -4595,12 +4592,12 @@ function makeTest(name, doc, mutation) {
 		equal(frag.firstChild.getAttribute("readonly"),"","readonly set");
 	});
 
-	test("keep @index working with multi-dimensional arrays (#2127)", function() {
+	test("keep %index working with multi-dimensional arrays (#2127)", function() {
 		var data = new CanMap({
 			array2 : [['asd'], ['sdf']]
 		});
 
-		var template = stache('<div>{{#each array2}}<span>{{@index}}</span>{{/each}}</div>');
+		var template = stache('<div>{{#each array2}}<span>{{%index}}</span>{{/each}}</div>');
 
 		var frag = template(data);
 


### PR DESCRIPTION
this PR close https://github.com/canjs/canjs/issues/2925 and https://github.com/canjs/can-stache/issues/19

to get `@` special keys fully removed we have to change:

- [x] can-observation -> `reader.js` (https://github.com/canjs/can-observation/blob/master/reader/reader.js#L254-L262) and rewrite tests 
-> done (https://github.com/canjs/can-observation/pull/50)

- [x] can-stache-bindings -> `can-stache-bindings.js` (https://github.com/canjs/can-stache-bindings/blob/master/can-stache-bindings.js#L278-L291) and rewrite tests
-> done(https://github.com/canjs/can-stache-bindings/pull/120)

this PR is against `major` branch because this is a breaking change and we are going to release can-stache 4.0