### PR TITLE
Add Observation.ignore to renderer functions

### DIFF
--- a/src/html_section.js
+++ b/src/html_section.js
@@ -1,5 +1,6 @@
 var target = require('can-view-target');
 var Scope = require('can-view-scope');
+var Observation = require('can-observation');
 
 var utils = require('./utils');
 var mustacheCore = require('./mustache_core');
@@ -68,8 +69,9 @@ assign(HTMLSectionBuilder.prototype,{
 	},
 	compile: function(){
 		var compiled = this.stack.pop().compile();
-
-		return function(scope, options, nodeList){
+		// ignore observations here.  the render fn
+		//  itself doesn't need to be observable.
+		return Observation.ignore(function(scope, options, nodeList){
 			if ( !(scope instanceof Scope) ) {
 				scope = Scope.refsScope().add(scope || {});
 			}
@@ -77,7 +79,7 @@ assign(HTMLSectionBuilder.prototype,{
 				options = new mustacheCore.Options(options || {});
 			}
 			return compiled.hydrate(scope, options, nodeList);
-		};
+		});
 	},
 	push: function(chars){
 		this.last().push(chars);

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5363,6 +5363,26 @@ function makeTest(name, doc, mutation) {
 		equal(innerHTML(p[1]), 'long', 'updated value for `is foo[bar].first "K"`');
 	});
 
+	test("renderer itself is not observable", function() {
+		var first = canCompute("Justin"),
+			last = canCompute("Meyer");
+
+		var renderer = stache("{{first}} {{last}}");
+
+		var fullNameFrag = canCompute(function(){
+			return renderer({first: first, last: last});
+		});
+
+		fullNameFrag.on("change", function(){
+			QUnit.ok(false);
+		});
+
+		this.fixture.appendChild(fullNameFrag());
+
+		first("Josh");
+		equal(this.fixture.innerHTML, "Josh Meyer");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
Fixes #128 by making renderer functions themselves non-observable while retaining the observability of their constituents.  In other words, renderers don't "leak" their observations into the scope creating the renderer.