### PR TITLE
Provide warnings for miss-matched starting and ending special tags

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -257,6 +257,10 @@ Call.prototype.value = function(scope, helperScope, helperOptions){
 
 };
 
+Call.prototype.closingTag = function() {
+	return this.methodExpr.key.slice(1);
+};
+
 // ### HelperLookup
 // An expression that looks up a value in the helper or scope.
 // Any functions found prior to the last one are called with
@@ -430,6 +434,10 @@ Helper.prototype.value = function(scope, helperOptions, nodeList, truthyRenderer
 	} else {
 		return computeValue;
 	}
+};
+
+Helper.prototype.closingTag = function() {
+	return this.methodExpr.key;
 };
 
 

--- a/src/html_section.js
+++ b/src/html_section.js
@@ -27,7 +27,7 @@ var decodeHTML = typeof document !== "undefined" && (function(){
 //
 //     {{#if items}} {{#items}} X
 //
-// At the point X was being processed, their would be 2 HTMLSections in the
+// At the point X was being processed, there would be 2 HTMLSections in the
 // stack.  One for the content of `{{#if items}}` and the other for the
 // content of `{{#items}}`
 var HTMLSectionBuilder = function(){

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -260,12 +260,23 @@ var core = {
 			fullExpression = mode+expressionString;
 
 		// convert a lookup like `{{value}}` to still be called as a helper if necessary.
+<<<<<<< HEAD
 		if(!(exprData instanceof expression.Helper) && !(exprData instanceof expression.Call)) {
 			exprData = new expression.Helper(exprData,[],{});
 		}
 
 		// A branching renderer takes truthy and falsey renderer.
 		return function branchRenderer(scope, options, truthyRenderer, falseyRenderer){
+=======
+		if (!(exprData instanceof expression.Helper) &&
+			!(exprData instanceof expression.Call)
+		) {
+			exprData = new expression.Helper(exprData, [], {});
+		}
+
+		// A branching renderer takes truthy and falsey renderer.
+		var branchRenderer = function branchRenderer(scope, options, truthyRenderer, falseyRenderer) {
+>>>>>>> edf54e5... refactor element stack, move closingTag logic to expression object (canjs/can-stache#13)
 			// Check the scope's cache if the evaluator already exists for performance.
 			var evaluator = scope.__cache[fullExpression];
 			if(mode || !evaluator) {
@@ -279,6 +290,10 @@ var core = {
 			var res = evaluator();
 			return res == null ? "" : ""+res;
 		};
+
+		branchRenderer.exprData = exprData;
+
+		return branchRenderer;
 	},
 	// ## mustacheCore.makeLiveBindingBranchRenderer
 	// Return a renderer function that evaluates the mustache expression and
@@ -303,7 +318,11 @@ var core = {
 			exprData = new expression.Helper(exprData,[],{});
 		}
 		// A branching renderer takes truthy and falsey renderer.
+<<<<<<< HEAD
 		return function branchRenderer(scope, options, parentSectionNodeList, truthyRenderer, falseyRenderer){
+=======
+		var branchRenderer = function branchRenderer(scope, options, parentSectionNodeList, truthyRenderer, falseyRenderer) {
+>>>>>>> edf54e5... refactor element stack, move closingTag logic to expression object (canjs/can-stache#13)
 
 			var nodeList = [this];
 			nodeList.expression = expressionString;
@@ -387,6 +406,10 @@ var core = {
 			// Unbind the compute.
 			computeValue.computeInstance.unbind("change", k);
 		};
+
+		branchRenderer.exprData = exprData;
+
+		return branchRenderer;
 	},
 	// ## mustacheCore.splitModeFromExpression
 	// Returns the mustache mode split from the rest of the expression.

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5388,11 +5388,35 @@ function makeTest(name, doc, mutation) {
 		QUnit.ok( viewCallbacks.tag("content"),"registered content" );
 	});
 
-	test("warn on missmatched tag (canjs/canjs#1476)", function() {
-		stache("{{#if someCondition}}...{{/someCondition}}");
-		stache("{{^if}}...{{/each}}");
-		stache("{{#if someCondition}}...{{/}}");
-	});
+	if (System.env.indexOf('production') < 0) {
+		test("warn on missmatched tag (canjs/canjs#1476)", function() {
+			var count = 0;
+			var texts = [
+				"unexpected closing tag {{/foo}} expected {{/if}}",
+				"unexpected closing tag {{/foo}} expected {{/if}}",
+				"unexpected closing tag {{/foo}} expected {{/call}}"
+			];
+			expect(texts.length);
+
+			var _warn = canDev.warn;
+			canDev.warn = function(text) {
+				equal(text, texts[count++]);
+			};
+
+			// Fails
+			stache("{{#if someCondition}}...{{/foo}}");
+			stache("{{^if someCondition}}...{{/foo}}");
+			stache("{{#call()}}...{{/foo}}");
+
+			// Successes
+			stache("{{#if}}...{{/}}");
+			stache("{{#if someCondition}}...{{/if}}");
+			stache("{{^if someCondition}}...{{/if}}");
+			stache("{{#call()}}...{{/call}}");
+
+			canDev.warn = _warn;
+		});
+	}
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5388,6 +5388,12 @@ function makeTest(name, doc, mutation) {
 		QUnit.ok( viewCallbacks.tag("content"),"registered content" );
 	});
 
+	test("warn on missmatched tag (canjs/canjs#1476)", function() {
+		stache("{{#if someCondition}}...{{/someCondition}}");
+		stache("{{^if}}...{{/each}}");
+		stache("{{#if someCondition}}...{{/}}");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
Part of fix for canjs/can-stache#13 and canjs/canjs#1476. Added warnings for improperly closed special tags.