### PR TITLE
Brackets with dots

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -58,7 +58,8 @@ var getKeyComputeData = function (key, scope, readOptions) {
 				observeReader.write(result, observeReader.reads(key), newVal);
 			} else {
 				// Convert possibly numeric key to string, because observeReader.get will do a charAt test on it.
-				return observeReader.get(result, "" + key);
+				// also escape `.` so that things like ["bar.baz"] will work correctly
+				return observeReader.get(result, ("" + key).replace(".", "\\."));
 			}
 		});
 

--- a/src/expression.js
+++ b/src/expression.js
@@ -101,13 +101,9 @@ Bracket.prototype.value = function (scope) {
 	var obj = this.root;
 
 	if (prop instanceof Lookup) {
-		prop = lookupValue(prop.key, scope, {}, {});
+		prop = lookupValue(prop.key, scope, {}, {}).value;
 	} else if (prop instanceof Call) {
 		prop = prop.value(scope, {}, {});
-	}
-
-	if (prop.computeData != null && prop.hasOwnProperty("value")) {
-		prop = prop.value;
 	}
 
 	if (!obj) {

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -562,6 +562,18 @@ test("Bracket expression", function(){
 	);
 	equal(compute(), "name");
 
+	// foo["bar.baz"]
+	expr = new expression.Bracket(
+		new expression.Literal("bar.baz"),
+		new expression.Lookup("foo")
+	);
+	compute = expr.value(
+		new Scope(
+			new CanMap({foo: {"bar.baz": "name"}})
+		)
+	);
+	equal(compute(), "name");
+
 	// foo[bar]
 	expr = new expression.Bracket(
 		new expression.Lookup("bar"),


### PR DESCRIPTION
This is the first piece of https://github.com/canjs/can-stache/issues/173.

Right now this works:
```
{{ foo["bar.baz"] }}
```

But this doesn't:

```
{{ ["bar.baz"] }}
```

You also cannot currently use two-way binding to update the property. Meaning this won't work:
```
<input {($value)}="foo['bar.baz']" >
```
