### PR TITLE
@arg's functions not executed

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -22,7 +22,7 @@ var looksLikeOptions = function(options){
 };
 
 var resolve = function (value) {
-	if (isFunction(value)) {
+	if (value && value.isComputed) {
 		return value();
 	} else {
 		return value;
@@ -154,7 +154,7 @@ var helpers = {
 		var value;
 		// if it's a function, wrap its value in a compute
 		// that will only change values from true to false
-		if (isFunction(expr)) {
+		if (expr && expr.isComputed) {
 			value = compute.truthy(expr)();
 		} else {
 			value = !! resolve(expr);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "donejs"
   ],
   "dependencies": {
-    "can-compute": "^3.0.8",
+    "can-compute": "^3.0.10",
     "can-namespace": "1.0.0",
     "can-observation": "^3.0.3",
     "can-route": "^3.0.5",

--- a/src/expression.js
+++ b/src/expression.js
@@ -274,6 +274,12 @@ var HelperScopeLookup = function(){
 	Lookup.apply(this, arguments);
 };
 HelperScopeLookup.prototype.value = function(scope, helperOptions){
+	if (this.key.charAt(0) === "@" && this.key !== "@index") {
+		return (function() {
+			return !!this.value;
+		}).bind(this);
+	}
+
 	return lookupValue(this.key, scope, helperOptions, {callMethodsOnObservables: true, isArgument: true, args: [scope.peek('.'), scope]}).value;
 };
 

--- a/src/expression.js
+++ b/src/expression.js
@@ -274,13 +274,19 @@ var HelperScopeLookup = function(){
 	Lookup.apply(this, arguments);
 };
 HelperScopeLookup.prototype.value = function(scope, helperOptions){
+	var value = lookupValue(this.key, scope, helperOptions, {
+		callMethodsOnObservables: true,
+		isArgument: true,
+		args: [ scope.peek('.'), scope ]
+	}).value;
+
 	if (this.key.charAt(0) === "@" && this.key !== "@index") {
 		return (function() {
-			return !!this.value;
+			return !!value();
 		}).bind(this);
 	}
 
-	return lookupValue(this.key, scope, helperOptions, {callMethodsOnObservables: true, isArgument: true, args: [scope.peek('.'), scope]}).value;
+	return value;
 };
 
 var Helper = function(methodExpression, argExpressions, hashExpressions){

--- a/src/expression.js
+++ b/src/expression.js
@@ -274,19 +274,11 @@ var HelperScopeLookup = function(){
 	Lookup.apply(this, arguments);
 };
 HelperScopeLookup.prototype.value = function(scope, helperOptions){
-	var value = lookupValue(this.key, scope, helperOptions, {
+	return lookupValue(this.key, scope, helperOptions, {
 		callMethodsOnObservables: true,
 		isArgument: true,
 		args: [ scope.peek('.'), scope ]
 	}).value;
-
-	if (this.key.charAt(0) === "@" && this.key !== "@index") {
-		return (function() {
-			return !!value();
-		}).bind(this);
-	}
-
-	return value;
 };
 
 var Helper = function(methodExpression, argExpressions, hashExpressions){

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -332,6 +332,8 @@ var core = {
 				computeValue = compute(evaluator, null, false);
 			}
 
+			var isAt = expressionString.charAt(0) === "@" && expressionString !== "@index";
+
 			computeValue.computeInstance.setPrimaryDepth(nodeList.nesting);
 
 			// Bind on the computeValue to set the cached value. This helps performance
@@ -341,7 +343,7 @@ var core = {
 			var value = computeValue();
 
 			// If value is a function, it's a helper that returned a function.
-			if(typeof value === "function") {
+			if(!isAt && typeof value === "function") {
 
 				// A helper function should do it's own binding.  Similar to how
 				// we prevented this function's compute from being noticed by parent expressions,

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -332,8 +332,6 @@ var core = {
 				computeValue = compute(evaluator, null, false);
 			}
 
-			var isAt = expressionString.charAt(0) === "@" && expressionString !== "@index";
-
 			computeValue.computeInstance.setPrimaryDepth(nodeList.nesting);
 
 			// Bind on the computeValue to set the cached value. This helps performance
@@ -343,7 +341,7 @@ var core = {
 			var value = computeValue();
 
 			// If value is a function, it's a helper that returned a function.
-			if(!isAt && typeof value === "function") {
+			if(typeof value === "function") {
 
 				// A helper function should do it's own binding.  Similar to how
 				// we prevented this function's compute from being noticed by parent expressions,

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5390,4 +5390,22 @@ function makeTest(name, doc, mutation) {
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
+	test("test", function() {
+		var data = {
+			func1: function() {
+				return "called";
+			},
+			func2: function() {
+				console.log('bam')
+				throw new Error("should not be called");
+			},
+			noop: undefined
+		};
+
+		equal(getText("{{func1}}", data), "called");
+		equal(getText("{{#if func1}}yes{{else}}no{{/if}}", data), "yes");
+		equal(getText("{{@func2}}", data), "function () { [native code] }");
+		equal(getText("{{#if @func2}}yes{{else}}no{{/if}}", data), "yes");
+	});
+
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5388,23 +5388,24 @@ function makeTest(name, doc, mutation) {
 		QUnit.ok( viewCallbacks.tag("content"),"registered content" );
 	});
 
-	// PUT NEW TESTS RIGHT BEFORE THIS!
-
-	test("test", function() {
-		var data = {
+	test("@arg functions are not called (#172)", function() {
+		var data = new DefineMap({
 			func1: function() {
 				return "called";
 			},
 			func2: function() {
-				throw new Error("should not be called");
+				console.log("should not be called");
+				return true;
 			},
 			noop: undefined
-		};
+		});
 
 		equal(getText("{{func1}}", data), "called");
 		equal(getText("{{#if func1}}yes{{else}}no{{/if}}", data), "yes");
 		equal(getText("{{@func2}}", data).replace(' bound ', ' ').slice(0, 13), "function () {");
 		equal(getText("{{#if @func2}}yes{{else}}no{{/if}}", data), "yes");
 	});
+
+	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5396,7 +5396,6 @@ function makeTest(name, doc, mutation) {
 				return "called";
 			},
 			func2: function() {
-				console.log('bam')
 				throw new Error("should not be called");
 			},
 			noop: undefined
@@ -5404,7 +5403,7 @@ function makeTest(name, doc, mutation) {
 
 		equal(getText("{{func1}}", data), "called");
 		equal(getText("{{#if func1}}yes{{else}}no{{/if}}", data), "yes");
-		equal(getText("{{@func2}}", data), "function () { [native code] }");
+		equal(getText("{{@func2}}", data).replace(' bound ', ' ').slice(0, 13), "function () {");
 		equal(getText("{{#if @func2}}yes{{else}}no{{/if}}", data), "yes");
 	});
 

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5402,12 +5402,10 @@ function makeTest(name, doc, mutation) {
 
 		equal(getText("{{func1}}", data), "called");
 		equal(getText("{{#if func1}}yes{{else}}no{{/if}}", data), "yes");
-		equal(getText("{{@func2}}", data).replace(' bound ', ' ').slice(0, 13), "function () {");
 		equal(getText("{{#if @func2}}yes{{else}}no{{/if}}", data), "yes");
 
 		equal(getText("{{noop}}", data), "");
 		equal(getText("{{#if noop}}yes{{else}}no{{/if}}", data), "no");
-		equal(getText("{{@noop}}", data), "");
 		equal(getText("{{#if @noop}}yes{{else}}no{{/if}}", data), "no");
 	});
 

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5394,7 +5394,7 @@ function makeTest(name, doc, mutation) {
 				return "called";
 			},
 			func2: function() {
-				console.log("should not be called");
+				ok(false, "this method should not be called.");
 				return true;
 			},
 			noop: undefined
@@ -5404,6 +5404,11 @@ function makeTest(name, doc, mutation) {
 		equal(getText("{{#if func1}}yes{{else}}no{{/if}}", data), "yes");
 		equal(getText("{{@func2}}", data).replace(' bound ', ' ').slice(0, 13), "function () {");
 		equal(getText("{{#if @func2}}yes{{else}}no{{/if}}", data), "yes");
+
+		equal(getText("{{noop}}", data), "");
+		equal(getText("{{#if noop}}yes{{else}}no{{/if}}", data), "no");
+		equal(getText("{{@noop}}", data), "");
+		equal(getText("{{#if @noop}}yes{{else}}no{{/if}}", data), "no");
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!


### PR DESCRIPTION
closes #172. Using "{{@func}}" or "{{#if @func}}" had been executing the function and using its value, rather than the function itself. (Actually, it appears that the first case was incidentally fixed in v3.0.21.)

I think there might be a better way to solve this, though I am unsure what it is. As best I can tell, because `if` always executes the [provided function](https://github.com/canjs/can-stache/blob/master/helpers/core.js#L153), the it needed to be changed to be one that validates the existence of the function, rather than the function itself.