### PR TITLE
add whitespace control (#60)

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -39,6 +39,7 @@ function stache(template){
 
 	// Remove line breaks according to mustache's specs.
 	if(typeof template === "string") {
+		template = mustacheCore.cleanWhitespaceControl(template);
 		template = mustacheCore.cleanLineEndings(template);
 	}
 

--- a/docs/whitespace.md
+++ b/docs/whitespace.md
@@ -7,15 +7,90 @@
 
 Whitespace may be omitted from either or both ends of a magic tag by including a
 `-` character by the braces. When present, all whitespace on that side will be
-omitted up to the next tag, magic tag, or non-whitespace character.
+omitted up to the next tag, magic tag, or non-whitespace character. It also works with [can-stache.tags.unescaped].
+
+@param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/helper} EXPRESSION An expression whose unescaped result is inserted into the page.
+
+@body
+
+## Examples
+
+### Basic Usage
 
 ```js
 <div>
-	{{-name-}}
+	{{-#if user.isMarried-}}
+		Mrs
+	{{-else-}}
+		Miss
+	{{-/if-}}
 </div>
+```
+
+would render as:
+
+```js
+<div>{{#if user.isMarried}}Mrs{{else}}Miss{{/if}}</div>
+```
+
+and
+
+```js
 <div>
 	{{{- toMarkdown(content) -}}}
 </div>
 ```
 
-@param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/helper} EXPRESSION An expression whose unescaped result is inserted into the page.
+would render as:
+
+```js
+<div>{{{ toMarkdown(content) }}}</div>
+```
+
+### Span Elements
+
+One use case is to remove spaces around span elements.
+
+```js
+<div>
+	<span>
+		{{-#if user.isMarried-}}
+			Mrs.
+		{{-else-}}
+			Miss.
+		{{-/if-}}
+	</span>
+	{{- user.name }}
+</div>
+```
+
+would render as:
+
+```js
+<div>
+	<span>{{#if user.isMarried}}Mrs.{{else}}Miss.{{/if}}</span>{{ user.name }}
+</div>
+```
+
+### Empty Elements
+
+Another would be to assure that empty elements are able to match the `:empty`
+css pseudo-class (the whitespace that would be otherwise present prevents this),
+while still being cleanly formatted for human consumption.
+
+```js
+<div>
+	{{-! output the users name }}
+	{{-#if user.name}}
+		{{ user.name }}
+	{{/if-}}
+</div>
+```
+
+would render as:
+
+```js
+<div>{{-! output the users name }}{{-#if user.name}}
+		{{ user.name }}
+	{{/if-}}</div>
+```

--- a/docs/whitespace.md
+++ b/docs/whitespace.md
@@ -1,0 +1,21 @@
+@page can-stache.Whitespace Whitespace Control
+@parent can-stache.pages 6
+
+@description Omit whitespace from around the output of the template.
+
+@signature `{{-EXPRESSION-}}`
+
+Whitespace may be omitted from either or both ends of a magic tag by including a
+`-` character by the braces. When present, all whitespace on that side will be
+omitted up to the next tag, magic tag, or non-whitespace character.
+
+```js
+<div>
+	{{-name-}}
+</div>
+<div>
+	{{{- toMarkdown(content) -}}}
+</div>
+```
+
+@param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/helper} EXPRESSION An expression whose unescaped result is inserted into the page.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-stache",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "description": "Live binding handlebars templates",
   "homepage": "http://canjs.com",
   "repository": {

--- a/src/intermediate_and_imports.js
+++ b/src/intermediate_and_imports.js
@@ -4,7 +4,10 @@ var parser = require('can-view-parser');
 
 module.exports = function(source){
 
-	var template = mustacheCore.cleanLineEndings(source);
+	var template = source;
+	template = mustacheCore.cleanWhitespaceControl(template);
+	template = mustacheCore.cleanLineEndings(template);
+
 	var imports = [],
 		dynamicImports = [],
 		ases = {},

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -27,7 +27,8 @@ var attr = require("can-util/dom/attr/attr");
 
 // ## Helpers
 
-var mustacheLineBreakRegExp = /(?:(?:^|(\r?)\n)(\s*)(\{\{([^\}]*)\}\}\}?)([^\S\n\r]*)($|\r?\n))|(\{\{([^\}]*)\}\}\}?)/g,
+var mustacheLineBreakRegExp = /(?:(?:^|(\r?)\n)(\s*)(\{\{([\s\S]*)\}\}\}?)([^\S\n\r]*)($|\r?\n))|(\{\{([\s\S]*)\}\}\}?)/g,
+	mustacheWhitespaceRegExp = /(\s*)(\{\{\{?)(-?)([\s\S]*?)(-?)(\}\}\}?)(\s*)/g,
 	k = function(){};
 
 
@@ -459,6 +460,40 @@ var core = {
 				// There is no mode, return special with spaces around it.
 				return spaceBefore+special+spaceAfter+(spaceBefore.length || matchIndex !== 0 ? returnBefore+"\n" : "");
 			}
+
+		});
+	},
+	// ## mustacheCore.cleanWhitespaceControl
+	// Removes whitespace according to the whitespace control.
+	/**
+	 * @hide
+	 * Prunes whitespace according to the whitespace control.
+	 * @param {String} template
+	 * @return {String}
+	 */
+	cleanWhitespaceControl: function(template) {
+
+		return template.replace(mustacheWhitespaceRegExp, function(
+			whole,
+			spaceBefore,
+			bracketBefore,
+			controlBefore,
+			expression,
+			controlAfter,
+			bracketAfter,
+			spaceAfter,
+			matchIndex
+		) {
+
+			if (controlBefore === '-') {
+				spaceBefore = '';
+			}
+
+			if (controlAfter === '-') {
+				spaceAfter = '';
+			}
+
+			return spaceBefore + bracketBefore + expression + bracketAfter + spaceAfter;
 
 		});
 	},

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -3,6 +3,7 @@ require('./expression-test');
 require('./stache-define-test');
 require('../helpers/route-test');
 var stache = require('can-stache');
+var core = require('can-stache/src/mustache_core');
 
 var QUnit = require('steal-qunit');
 var CanMap = require('can-map');
@@ -5386,6 +5387,32 @@ function makeTest(name, doc, mutation) {
 
 	QUnit.test("content is registered (#163)",function(){
 		QUnit.ok( viewCallbacks.tag("content"),"registered content" );
+	});
+
+	test("whitespace control (#60)", function() {
+		equal(core.cleanWhitespaceControl(
+			"<foo> {{-message-}} </foo>"),
+			"<foo>{{message}}</foo>");
+		equal(core.cleanWhitespaceControl(
+			"<foo> {{{-message-}}} </foo>"),
+			"<foo>{{{message}}}</foo>");
+		equal(core.cleanWhitespaceControl(
+			"<foo> {{- name -}} </foo><foo> {{{- name -}}} </foo>"),
+			"<foo>{{ name }}</foo><foo>{{{ name }}}</foo>");
+		equal(core.cleanWhitespaceControl(
+			"<foo> {{-#data-}} {{->list-}} {{-/data-}} </foo>"),
+			"<foo>{{#data}}{{>list}}{{/data}}</foo>");
+		equal(core.cleanWhitespaceControl(
+			"<foo>\n\t{{-! comment -}}\n</foo>"),
+			"<foo>{{! comment }}</foo>");
+
+		var div = doc.createElement('div');
+		div.appendChild(stache("<foo>\n\t{{-! comment -}}\n</foo>")());
+		equal(div.innerHTML, '<foo></foo>');
+
+		if (typeof div.querySelectorAll === 'function') {
+			equal(div.querySelectorAll(':empty').length, 1);
+		}
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!


### PR DESCRIPTION
Added whitespace control via `-`. I attempted to make it part of `cleanLineEndings` out of efficiency, but the match there only catches certain kinds of whitespace. Instead, I added it as a pre-processor that runs first.
For #60 

Examples:
* "<foo> {{-message-}} </foo>" will be rendered as "<foo>{{message}}</foo>"
* "<foo> {{{-message-}}} </foo>" will be rendered as "<foo>{{{message}}}</foo>"
* "<foo> {{- name -}} </foo><foo> {{{- name -}}} </foo>" will be rendered as "<foo>{{ name }}</foo><foo>{{{ name }}}</foo>"
* "<foo> {{-#data-}} {{->list-}} {{-/data-}} </foo>" will be rendered as "<foo>{{#data}}{{>list}}{{/data}}</foo>"
* "<foo>\n\t{{-! comment -}}\n</foo>" will be rendered as "<foo>{{! comment }}</foo>"