### PR TITLE
add warning when helpers overwrite existing ones

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -13,6 +13,7 @@ var joinURIs = require('can-util/js/join-uris/join-uris');
 var each = require('can-util/js/each/each');
 var assign = require('can-util/js/assign/assign');
 var isIterable = require("can-util/js/is-iterable/is-iterable");
+var dev = require('can-util/js/dev/dev');
 
 
 var domData = require('can-util/dom/data/data');
@@ -285,6 +286,12 @@ var helpers = {
 helpers.eachOf = helpers.each;
 
 var registerHelper = function(name, callback){
+	//!steal-remove-start
+	if (helpers[name]) {
+		dev.warn('The helper ' + name + ' has already been registered.');
+	}
+	//!steal-remove-end
+
 	helpers[name] = callback;
 };
 

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -165,6 +165,20 @@ function makeTest(name, doc, mutation) {
 
 	});
 
+	test("helpers warn on overwrite (canjs/can-stache-converters#24)", function () {
+
+		var oldWarn = canDev.warn;
+		canDev.warn = function() {
+			ok(true, "received warning");
+		};
+
+		stache.registerHelper('foobar', function() {});
+		stache.registerHelper('foobar', function() {});
+
+		canDev.warn = oldWarn;
+
+	});
+
 	/*test("attribute sections", function(){
 	 var stashed = stache("<h1 style='top: {{top}}px; left: {{left}}px; background: rgb(0,0,{{color}});'>Hi</h1>");
 


### PR DESCRIPTION
fixes canjs/can-stache-converters#24