### PR TITLE
Remove helperOptions.fn and helperOptions.inverse in case of inline helper

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -407,6 +407,10 @@ Helper.prototype.evaluator = function(helper, scope, helperOptions, /*REMOVE*/re
 		helpers: helperOptions
 	});
 
+	if (!truthyRenderer) {
+		delete helperOptionArg.fn;
+	}
+
 	args.push(helperOptionArg);
 	// Call the helper.
 	return function () {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -165,6 +165,25 @@ function makeTest(name, doc, mutation) {
 
 	});
 
+	test("helperOptions.fn and helperOptions.inverse included with section helpers but not inline helpers", 4, function() {
+
+		var inlineHelper = stache("{{inlineHelper}} {{#sectionHelper}}section helper called{{/sectionHelper}}");
+
+		inlineHelper({}, {
+			inlineHelper: function (helperOptions) {
+				console.log('inline helper');
+				ok(helperOptions.fn === undefined);
+				ok(helperOptions.inverse() === undefined);
+			},
+			sectionHelper: function (helperOptions) {
+				console.log('section helper');
+				ok(helperOptions.fn() !== undefined);
+				ok(helperOptions.inverse() === undefined);
+			}
+		});
+
+	});
+
 	test("helpers warn on overwrite (canjs/can-stache-converters#24)", function () {
 
 		var oldWarn = canDev.warn;


### PR DESCRIPTION
There is no need for inline helpers to have helperOptions.fn and helperOptions.inverse be an empty JS function that returns undefined.  The plan is to remove these methods from helperOptions if the helper was called as an inline helper.

Inline helper
`{{inlineHelper}}`

Section helper
`{{#sectionHelper}}children{{/sectionHelper}}`