### PR TITLE
Makes #each helper diff POJO arrays computes

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -62,7 +62,10 @@ var helpers = {
 			}
 		}
 
-		if (types.isListLike(resolved) && !options.stringOnly) {
+		if ((
+				types.isListLike(resolved) ||
+				( utils.isArrayLike(resolved) && items.isComputed )
+			) && !options.stringOnly) {
 			return function(el){
 				// make a child nodeList inside the can.view.live.html nodeList
 				// so that if the html is re

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5462,6 +5462,32 @@ function makeTest(name, doc, mutation) {
 		equal(getText("{{#if @noop}}yes{{else}}no{{/if}}", data), "no");
 	});
 
+	test("#each with arrays (#215)", function(){
+		var which = canCompute(false);
+		var a = {}, b = {}, c = {};
+
+		var list = canCompute(function(){
+		  return which() ? [a,b,c]: [a,c];
+		});
+
+		var template = stache("<ul>{{#each list}}<li/>{{/each}}</ul>");
+		var frag = template({list: list});
+
+		var ul = frag.firstChild;
+		var lis = ul.getElementsByTagName("li");
+		var aLI = lis[0],
+			cLI = lis[1];
+
+		which(true);
+
+		lis = ul.getElementsByTagName("li");
+		var aLI2 = lis[0],
+			cLI2 = lis[2];
+
+		QUnit.equal(aLI, aLI2, "a li was reused");
+		QUnit.equal(cLI, cLI2, "c li was reused");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
fixes #215 

Allows a compute with an array to use diffing similar to the following example:

```
var which = compute(false);
var a = {}, b = {}, c = {};

var list = compute(function(){
  return which() ? [a,c]: [a,b,c]
});

stache("{{#each list}}...");
```