### PR TITLE
Plain js objects now work with subtemplate

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -249,7 +249,7 @@ function stache(template){
 						viewCallbacks.tagHandler(this,tagName, {
 							scope: scope,
 							options: options,
-							subtemplate: renderer,
+							subtemplate: makeRendererConvertScopes(renderer),
 							templateType: "stache",
 							parentNodeList: parentNodeList,
 							templates: current.templates

--- a/can-stache.js
+++ b/can-stache.js
@@ -249,7 +249,7 @@ function stache(template){
 						viewCallbacks.tagHandler(this,tagName, {
 							scope: scope,
 							options: options,
-							subtemplate: makeRendererConvertScopes(renderer),
+							subtemplate: renderer  ? makeRendererConvertScopes(renderer) : renderer,
 							templateType: "stache",
 							parentNodeList: parentNodeList,
 							templates: current.templates

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -1130,7 +1130,7 @@ function makeTest(name, doc, mutation) {
 		ul.appendChild(compiled);
 
 		equal( innerHTML(ul.getElementsByTagName('li')[0]), 'No items', 'initial observable state');
-		
+
 		obs.attr('items', [{
 			name: 'foo'
 		}]);
@@ -5531,6 +5531,25 @@ function makeTest(name, doc, mutation) {
 
 		QUnit.equal(aLI, aLI2, "a li was reused");
 		QUnit.equal(cLI, cLI2, "c li was reused");
+	});
+
+	test("Plain JS object scope works with subtemplate (#208)", function(){
+
+		expect(4);
+
+		viewCallbacks.tag("stache-tag", function(el, tagData){
+			ok(tagData.scope instanceof Scope, "got scope");
+			ok(tagData.options instanceof Scope, "got options");
+			equal(typeof tagData.subtemplate, "function", "got subtemplate");
+			var frag = tagData.subtemplate({last: "Meyer"}, tagData.options);
+
+			equal( innerHTML(frag.firstChild), "Meyer", "rendered right");
+		});
+
+		var template = stache("<stache-tag><span>{{last}}</span></stache-tag>")
+
+		template({});
+
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!


### PR DESCRIPTION
Fixes https://github.com/canjs/can-stache/issues/208
<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
