### PR TITLE
Remove options scope comment to fix bit-docs bug

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,10 +8,7 @@ var isArrayLike = require('can-util/js/is-array-like/is-array-like');
 	// ## can.view.Options
 	//
 	// This contains the local helpers, partials, and tags available to a template.
-	/**
-	 * @hide
-	 * The Options scope.
-	 */
+
 var Options = Scope.Options; // jshint ignore:line
 
 module.exports = {


### PR DESCRIPTION
Fixes bit-doc bug that adds a link to the options @param in the documentation for another module.

Previously automatically added a link:
![image](https://user-images.githubusercontent.com/3348231/28190138-f3f6d834-67ee-11e7-83c3-d3ff70d1a55b.png)
which linked to this empty page:
![image](https://user-images.githubusercontent.com/3348231/28190142-fc529086-67ee-11e7-85a2-a53a5a49a12f.png)

Now, link is removed:
![image](https://user-images.githubusercontent.com/3348231/28190125-e431858e-67ee-11e7-8006-cd5277fac148.png)
