### PR TITLE
Check attr names and give warning if no callback

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -29,6 +29,7 @@ viewCallbacks.tag("content", function(el, tagData) {
 	return tagData.scope;
 });
 
+var wrappedAttrPattern = /[{(].*[)}]/;
 var svgNamespace = "http://www.w3.org/2000/svg";
 var namespaces = {
 	"svg": svgNamespace,
@@ -282,7 +283,13 @@ function stache(template){
 				state.node.attrs[state.attr.name] =
 					state.attr.section ? state.attr.section.compile(copyState()) : state.attr.value;
 
+				weirdAttribute = !!wrappedAttrPattern.test(attrName);
 				var attrCallback = viewCallbacks.attr(attrName);
+
+				if (weirdAttribute && !attrCallback) {
+					dev.warn("unknown attribute binding " + attrName + ". Is can-stache-bindings imported?");
+				}
+
 				if(attrCallback) {
 					if( !state.node.attributes ) {
 						state.node.attributes = [];
@@ -296,8 +303,6 @@ function stache(template){
 						});
 					});
 				}
-
-
 
 				state.attr = null;
 			}

--- a/can-stache.js
+++ b/can-stache.js
@@ -283,12 +283,14 @@ function stache(template){
 				state.node.attrs[state.attr.name] =
 					state.attr.section ? state.attr.section.compile(copyState()) : state.attr.value;
 
-				weirdAttribute = !!wrappedAttrPattern.test(attrName);
 				var attrCallback = viewCallbacks.attr(attrName);
 
+				//!steal-remove-start
+				weirdAttribute = !!wrappedAttrPattern.test(attrName);
 				if (weirdAttribute && !attrCallback) {
 					dev.warn("unknown attribute binding " + attrName + ". Is can-stache-bindings imported?");
 				}
+				//!steal-remove-end
 
 				if(attrCallback) {
 					if( !state.node.attributes ) {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5467,6 +5467,29 @@ function makeTest(name, doc, mutation) {
 		});
 	}
 
+	if (System.env.indexOf('production') < 0) {
+		test("warn on unknown attributes (canjs/can-stache#139)", function() {
+			var makeWarnChecks = function(input, texts) {
+				var count = 0;
+				var _warn = canDev.warn;
+				canDev.warn = function(text) {
+					equal(text, texts[count++]);
+				};
+
+				stache(input);
+
+				equal(count, texts.length);
+
+				canDev.warn = _warn;
+			};
+
+			// Fails
+			makeWarnChecks("<button ($weirdattribute)='showMessage()'>Click</button>", [
+				"unknown attribute binding ($weirdattribute). Is can-stache-bindings imported?"
+			]);
+		});
+	}
+
 	test("@arg functions are not called (#172)", function() {
 		var data = new DefineMap({
 			func1: function() {


### PR DESCRIPTION
Check if each stache attribute name is wrapped in `()` or `{}` and if it is and has no callback from `can-view-callbacks` then make a dev warning that asks if `can-stache-bindings` is imported.

for #139 