### PR TITLE
warn users when using colon binding syntaxe without importing can-stache-bindings

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -31,6 +31,7 @@ viewCallbacks.tag("content", function(el, tagData) {
 });
 
 var wrappedAttrPattern = /[{(].*[)}]/;
+var colonWrappedAttrPattern = /^on:|(:to|:from|:bind)$|.*:to:on:.*/;
 var svgNamespace = "http://www.w3.org/2000/svg";
 var namespaces = {
 	"svg": svgNamespace,
@@ -296,7 +297,7 @@ function stache (template) {
 
 				//!steal-remove-start
 				var decodedAttrName = attributeEncoder.decode(attrName);
-				weirdAttribute = !!wrappedAttrPattern.test(decodedAttrName);
+				weirdAttribute = !!wrappedAttrPattern.test(decodedAttrName) || !!colonWrappedAttrPattern.test(decodedAttrName);
 				if (weirdAttribute && !attrCallback) {
 					dev.warn("unknown attribute binding " + decodedAttrName + ". Is can-stache-bindings imported?");
 				}

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5775,6 +5775,26 @@ function makeTest(name, doc, mutation) {
 		ok( fraghtml.indexOf( "<li>goku<ul><li>gohan<ul><\/ul><\/li><\/ul><\/li>" ) !== -1 );
 	});
 
+	if (System.env.indexOf('production') < 0) {
+		test("warn when using on:, :to:on:, :to, :from or :bind without importing can-stache-bindings (#273)", function(assert) {
+			expect(5);
+			var expr = /unknown attribute binding/;
+			var warn = function(text) {
+				ok(expr.test(text));
+			};
+			clone({
+				'can-stache-bindings': {},
+				'can-util/js/dev/dev': {
+					warn: warn
+				}
+			})
+			.import('can-stache')
+			.then(function(stache) {
+				stache('<a on:click="theProp" value:to:on:click="theProp"  value:to="theProp" value:from="theProp" value:bind="theProp">a link</a>');
+			});
+		});
+	}
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
This fixes https://github.com/canjs/can-stache/issues/273