### PR TITLE
Add normalized leading space when mustacheLineBreakRegExp is matched

### DIFF
--- a/src/html_section.js
+++ b/src/html_section.js
@@ -27,7 +27,7 @@ var decodeHTML = typeof document !== "undefined" && (function(){
 //
 //     {{#if items}} {{#items}} X
 //
-// At the point X was being processed, their would be 2 HTMLSections in the
+// At the point X was being processed, there would be 2 HTMLSections in the
 // stack.  One for the content of `{{#if items}}` and the other for the
 // content of `{{#items}}`
 var HTMLSectionBuilder = function(){

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -458,10 +458,11 @@ var core = {
 			if(spaceLessSpecial || ">{".indexOf( modeAndExpression.mode) >= 0) {
 				return whole;
 			}  else if( "^#!/".indexOf(  modeAndExpression.mode ) >= 0 ) {
-
 				// Return the magic tag and a trailing linebreak if this did not
 				// start a new line and there was an end line.
-				return special+( matchIndex !== 0 && returnAfter.length ? returnBefore+"\n" :"");
+				// Add a normalized leading space, if there was any leading space, in case this abuts a tag name
+				spaceBefore = spaceBefore && " ";
+				return spaceBefore+special+( matchIndex !== 0 && returnAfter.length ? returnBefore+"\n" :"");
 
 
 			} else {

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -26,7 +26,7 @@ var canReflect = require("can-reflect");
 
 // ## Helpers
 
-var mustacheLineBreakRegExp = /(?:(?:^|(\r?)\n)(\s*)(\{\{([\s\S]*)\}\}\}?)([^\S\n\r]*)($|\r?\n))|(\{\{([\s\S]*)\}\}\}?)/g,
+var mustacheLineBreakRegExp = /(?:(^|(?:\r?)\n)(\s*)(\{\{([\s\S]*)\}\}\}?)([^\S\n\r]*)($|\r?\n))|(\{\{([\s\S]*)\}\}\}?)/g,
 	mustacheWhitespaceRegExp = /(\s*)(\{\{\{?)(-?)([\s\S]*?)(-?)(\}\}\}?)(\s*)/g,
 	k = function(){};
 
@@ -461,7 +461,7 @@ var core = {
 				// Return the magic tag and a trailing linebreak if this did not
 				// start a new line and there was an end line.
 				// Add a normalized leading space, if there was any leading space, in case this abuts a tag name
-				spaceBefore = spaceBefore && " ";
+				spaceBefore = (returnBefore + spaceBefore) && " ";
 				return spaceBefore+special+( matchIndex !== 0 && returnAfter.length ? returnBefore+"\n" :"");
 
 

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -26,7 +26,7 @@ var canReflect = require("can-reflect");
 
 // ## Helpers
 
-var mustacheLineBreakRegExp = /(?:(^|(?:\r?)\n)(\s*)(\{\{([\s\S]*)\}\}\}?)([^\S\n\r]*)($|\r?\n))|(\{\{([\s\S]*)\}\}\}?)/g,
+var mustacheLineBreakRegExp = /(?:(^|\r?\n)(\s*)(\{\{([\s\S]*)\}\}\}?)([^\S\n\r]*)($|\r?\n))|(\{\{([\s\S]*)\}\}\}?)/g,
 	mustacheWhitespaceRegExp = /(\s*)(\{\{\{?)(-?)([\s\S]*?)(-?)(\}\}\}?)(\s*)/g,
 	k = function(){};
 

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5806,6 +5806,13 @@ function makeTest(name, doc, mutation) {
 		});
 	}
 
+	test("newline is a valid special tag white space", function() {
+		var renderer = stache('<div\n\t{{#unless ./hideIt}}\n\t\thidden\n\t{{/unless}}\n>peekaboo</div>');
+		var html = renderer({ hideIt: true });
+
+		QUnit.ok(html, "markup was generated");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5811,6 +5811,13 @@ function makeTest(name, doc, mutation) {
 		var html = renderer({ hideIt: true });
 
 		QUnit.ok(html, "markup was generated");
+
+		// almost the same, but no leading spaces before {{#unless
+		renderer = stache('<div\n{{#unless ./hideIt}}\n\t\thidden\n\t{{/unless}}\n>peekaboo</div>');
+		html = renderer({ hideIt: true });
+
+		QUnit.ok(html, "markup was generated");
+
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!


### PR DESCRIPTION
This fixes the case where a mustache section block occurs after a tag name and a line break.  Previously the magic tags would adjoin the tag name and the Stache parser would interpret this whole expression (up to the next space) as the tag name.  This fix adds a leading space before the magic tags where warranted.

Edit: also found and fixed an issue with the line break regexp, where the non-capturing group `(?:^|(\r?)\n)` containing a capturing group of a carriage return, should have been a capturing group containing all of the aforementioned content, carriage return included, instead.  This made it possible to determine whether there was a leading newline in all line-ending schemes.

Fixes #256 