### PR TITLE
Check for hash expression before literal numbers in Stache Helper expr

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -776,22 +776,8 @@ var expression = {
 
 			cursor.index++;
 
-			// Literal
-			if(literalRegExp.test( token )) {
-				convertToHelperIfTopIsLookup(stack);
-				// only add to hash if there's not already a child.
-				firstParent = stack.first(["Helper", "Call", "Hash", "Bracket"]);
-				if(firstParent.type === "Hash" && (firstParent.children && firstParent.children.length > 0)) {
-					stack.addTo(["Helper", "Call", "Bracket"], {type: "Literal", value: utils.jsonParse( token )});
-				} else if(firstParent.type === "Bracket" && (firstParent.children && firstParent.children.length > 0)) {
-					stack.addTo(["Helper", "Call", "Hash"], {type: "Literal", value: utils.jsonParse( token )});
-				} else {
-					stack.addTo(["Helper", "Call", "Hash", "Bracket"], {type: "Literal", value: utils.jsonParse( token )});
-				}
-
-			}
 			// Hash
-			else if(nextToken === "=") {
+			if(nextToken === "=") {
 				//convertToHelperIfTopIsLookup(stack);
 				top = stack.top();
 
@@ -826,6 +812,20 @@ var expression = {
 					stack.push(hash);
 				}
 				cursor.index++;
+
+			}
+			// Literal
+			else if(literalRegExp.test( token )) {
+				convertToHelperIfTopIsLookup(stack);
+				// only add to hash if there's not already a child.
+				firstParent = stack.first(["Helper", "Call", "Hash", "Bracket"]);
+				if(firstParent.type === "Hash" && (firstParent.children && firstParent.children.length > 0)) {
+					stack.addTo(["Helper", "Call", "Bracket"], {type: "Literal", value: utils.jsonParse( token )});
+				} else if(firstParent.type === "Bracket" && (firstParent.children && firstParent.children.length > 0)) {
+					stack.addTo(["Helper", "Call", "Hash"], {type: "Literal", value: utils.jsonParse( token )});
+				} else {
+					stack.addTo(["Helper", "Call", "Hash", "Bracket"], {type: "Literal", value: utils.jsonParse( token )});
+				}
 
 			}
 			// Lookup

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5806,6 +5806,29 @@ function makeTest(name, doc, mutation) {
 		});
 	}
 
+	test("numbers can be used as hash keys (#203)", function() {
+		stache.registerHelper("globalValue", function(prop, options) {
+			return prop + ":" + (options.hash[0] || options.hash.zero);
+		});
+
+		var renderer = stache("<p>{{globalValue 'value' 0='indexed'}}</p>");
+		var frag = renderer({});
+
+		var fraghtml = innerHTML(frag.lastChild);
+
+		equal(fraghtml, "value:indexed");
+
+		// sanity check -- exact same thing should work for string key here
+		renderer = stache("<p>{{globalValue 'value' zero='strung'}}</p>");
+		frag = renderer({});
+
+		fraghtml = innerHTML(frag.lastChild);
+
+		equal(fraghtml, "value:strung");
+
+
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
In legacy can-mustache, one could write a hash expression in helper invocations like
`foo='bar'`
to get a hash key of `"foo"`, as well as writing
`0="baz"`
to get a hash key of numeral 0.  

can-stache did not check whether a literal was the key for a hash expression before interpreting it as a literal positional parameter in a helper expression.  This fix checks for a hash expression before parsing a token as a literal, allowing 0 and other integer numbers as hash keys.

Note that quoted strings are also supported by the implementation (with meaningful quotes), but this is not part of our spec and should not be relied on in the future.

Fixes #203 