### PR TITLE
Fix incorrect tag mismatch warnings for Call expressions with dots in the method lookup

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -890,7 +890,7 @@ var expression = {
 				top = stack.top();
 				if(top.type === "Lookup") {
 					//!steal-remove-start
-					//This line is just for matching stache brackets elsewhere,
+					//This line is just for matching stache magic tags elsewhere,
 					// because convertToAtLookup modifies the original key
 					canReflect.setKeyValue(top, canSymbol.for("can-stache.originalKey"), top.key);
 					//!steal-remove-end

--- a/src/expression.js
+++ b/src/expression.js
@@ -274,7 +274,12 @@ Call.prototype.value = function(scope, helperScope, helperOptions){
 };
 
 Call.prototype.closingTag = function() {
-	return this.methodExpr.key.slice(1);
+	//!steal-remove-start
+	if(this.methodExpr[canSymbol.for('can-stache.originalKey')]) {
+		return this.methodExpr[canSymbol.for('can-stache.originalKey')];
+	}
+	//!steal-remove-end
+	return this.methodExpr.key;
 };
 
 // ### HelperLookup
@@ -708,7 +713,11 @@ var expression = {
 	hydrateAst: function(ast, options, methodType, isArg){
 		var hashes;
 		if(ast.type === "Lookup") {
-			return new (options.lookupRule(ast, methodType, isArg))(ast.key, ast.root && this.hydrateAst(ast.root, options, methodType) );
+			var lookup = new (options.lookupRule(ast, methodType, isArg))(ast.key, ast.root && this.hydrateAst(ast.root, options, methodType) );
+			//!steal-remove-start
+			canReflect.setKeyValue(lookup, canSymbol.for("can-stache.originalKey"), ast[canSymbol.for("can-stache.originalKey")]);
+			//!steal-remove-end
+			return lookup;
 		}
 		else if(ast.type === "Literal") {
 			return new Literal(ast.value);
@@ -880,6 +889,11 @@ var expression = {
 			else if(token === "(") {
 				top = stack.top();
 				if(top.type === "Lookup") {
+					//!steal-remove-start
+					//This line is just for matching stache brackets elsewhere,
+					// because convertToAtLookup modifies the original key
+					canReflect.setKeyValue(top, canSymbol.for("can-stache.originalKey"), top.key);
+					//!steal-remove-end
 					stack.replaceTopAndPush({
 						type: "Call",
 						method: convertToAtLookup(top)

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5804,6 +5804,22 @@ function makeTest(name, doc, mutation) {
 				stache('<a on:click="theProp" value:to:on:click="theProp"  value:to="theProp" value:from="theProp" value:bind="theProp">a link</a>');
 			});
 		});
+
+
+		test("Don't warn about tag mismatch for Call expressions with dots in the method lookup (#214)", function() {
+			var oldWarn = canDev.warn;
+			canDev.warn = function() {
+				QUnit.ok(false, "Should not have warned about matching tags");
+			};
+			stache(
+				'{{#games.getAvailableCourts(selectedRound)}}' +
+		   		'<option value="{{.}}">{{.}}</option>' +
+				'{{/games.getAvailableCourts}}'
+			);
+
+			QUnit.ok(true, "Need an assertion");
+			canDev.warn = oldWarn;
+		});
 	}
 
 	test("newline is a valid special tag white space", function() {
@@ -5843,3 +5859,4 @@ function makeTest(name, doc, mutation) {
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }
+


### PR DESCRIPTION
Fixes #214

Note that the use of symbols for setting originalKey on the AST objects is to preserve the same test functionality in tests between dev and production (six of the tests in can-stache compare the output AST object to a known object, and introducing extra keys in dev only breaks that).

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
