### PR TITLE
Added test for with and multiple keys

### DIFF
--- a/docs/helpers/with.md
+++ b/docs/helpers/with.md
@@ -19,6 +19,22 @@ Renders `BLOCK` with the result of `EXPRESSION` added to the top of the [can-vie
 @param {can-stache.sectionRenderer} BLOCK A template that is rendered
 with the context of the `EXPRESSION`'s value.
 
+@signature `{{#with HASHES}}BLOCK{{/with}}`
+
+Renders `BLOCK` with the key-value pairs from a [can-stache/expressions/hash] added to the top of the [can-view-scope].
+
+```
+{{#with _street=person.address.street _city=person.address.city}}
+    Street: {{_street}}
+    City: {{_city}}
+{{/with}}
+```
+
+@param {can-stache/expressions/hash} HASHES Any number of hash keys and values
+
+@param {can-stache.sectionRenderer} BLOCK A template that is rendered
+with the hashes added to the context.
+
 @body
 
 ## Use
@@ -39,6 +55,23 @@ RESULT:
 	Street: 123 Evergreen
 	City: Springfield
 ```
+
+The new context can be a lookup expression, or a set of hashes which are taken together to be a new context.
+
+```
+TEMPLATE:
+	{{#with _street=person.address.street _city=person.address.city}}
+		Street: {{_street}}
+		City: {{_city}}
+	{{/with}}
+DATA:
+	{person: {address: {street: "123 Evergreen", city: "Springfield"}}}
+
+RESULT:
+	Street: 123 Evergreen
+	City: Springfield
+```
+
 
 The difference between `{{#with}}` and the default [can-stache.tags.section]
 is that the subsection `BLOCK` is rendered no matter what:

--- a/docs/helpers/with.md
+++ b/docs/helpers/with.md
@@ -24,9 +24,9 @@ with the context of the `EXPRESSION`'s value.
 Renders `BLOCK` with the key-value pairs from a [can-stache/expressions/hash] added to the top of the [can-view-scope].
 
 ```
-{{#with _street=person.address.street _city=person.address.city}}
-    Street: {{_street}}
-    City: {{_city}}
+{{#with innerStreet=person.address.street innerCity=person.address.city}}
+    Street: {{innerStreet}}
+    City: {{innerCity}}
 {{/with}}
 ```
 
@@ -60,9 +60,9 @@ The new context can be a lookup expression, or a set of hashes which are taken t
 
 ```
 TEMPLATE:
-	{{#with _street=person.address.street _city=person.address.city}}
-		Street: {{_street}}
-		City: {{_city}}
+	{{#with innerStreet=person.address.street innerCity=person.address.city}}
+		Street: {{innerStreet}}
+		City: {{innerCity}}
 	{{/with}}
 DATA:
 	{person: {address: {street: "123 Evergreen", city: "Springfield"}}}

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -11,6 +11,7 @@ var isIterable = require("can-util/js/is-iterable/is-iterable");
 var dev = require('can-util/js/dev/dev');
 var canSymbol = require("can-symbol");
 var canReflect = require("can-reflect");
+var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
 var debuggerHelper = require('./-debugger').helper;
 
 var domData = require('can-util/dom/data/data');
@@ -199,22 +200,19 @@ var helpers = {
 	'with': function (expr, options) {
 		var ctx = expr;
 		if(!options) {
-			// hash only.  Don't assume inverse based on lack of expr.
+			// hash-only case if no current context expression
 			options = expr;
 			expr = true;
 			ctx = options.hash;
 		} else {
 			expr = resolve(expr);
-			if(options.hash) {
+			if(options.hash && !isEmptyObject(options.hash)) {
 				// presumably rare case of both a context object AND hash keys
+				// Leaving it undocumented for now, but no reason not to support it.
 				ctx = options.scope.add(options.hash).add(ctx);
 			}
 		}
-		if ( !! expr) {
-			return options.fn(ctx);
-		} else {
-			return options.inverse(ctx);
-		}
+		return options.fn(ctx || {});
 	},
 	'log': function (options) {
 		// go through the arguments

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -198,9 +198,22 @@ var helpers = {
 	},
 	'with': function (expr, options) {
 		var ctx = expr;
-		expr = resolve(expr);
+		if(!options) {
+			// hash only.  Don't assume inverse based on lack of expr.
+			options = expr;
+			expr = true;
+			ctx = options.hash;
+		} else {
+			expr = resolve(expr);
+			if(options.hash) {
+				// presumably rare case of both a context object AND hash keys
+				ctx = options.scope.add(options.hash).add(ctx);
+			}
+		}
 		if ( !! expr) {
 			return options.fn(ctx);
+		} else {
+			return options.inverse(ctx);
 		}
 	},
 	'log': function (options) {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5976,6 +5976,27 @@ function makeTest(name, doc, mutation) {
 		equal(fraghtml, "value:strung");
 	});
 
+	test("Can assign multiple keys using with (#274)", function() {
+		var viewModel = new DefineMap({
+			person: {
+				first: "John",
+				last: "Gardner"
+			}
+		});
+
+		var renderer = stache(
+			"{{#with first=person.first last=person.last}}" +
+				"<span>{{first}}</span>" +
+				"<span>{{last}}</span>" +
+			"{{/with}}"
+		);
+
+		var view = renderer(viewModel);
+
+		equal(view.children[0].firstChild.nodeValue, "John", "Got the first name");
+		equal(view.children[1].firstChild.nodeValue, "Gardner", "Got the last name");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -778,6 +778,19 @@ function makeTest(name, doc, mutation) {
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(getText(t.template,t.data), expected);
+
+		var v = {
+			template: "{{#with person}}{{name}}{{/with}}",
+			expected: "Andy",
+			data: {
+				person: null,
+				name: "Andy"
+			}
+		};
+
+		expected = v.expected.replace(/&quot;/g, '&#34;')
+			.replace(/\r\n/g, '\n');
+		deepEqual(getText(v.template,v.data), expected);
 	});
 
 
@@ -1614,8 +1627,8 @@ function makeTest(name, doc, mutation) {
 		var inv_staches = {
 			"else": "{{#if test}}if{{else}}else{{/if}}",
 			"not_not_if": "not_{{^if test}}not_{{/if}}if",
-			"not_each": "not_{{#each test}}_{{/each}}each",
-			"not_with": "not{{#with test}}_{{/with}}_with"
+			"not_each": "not_{{#each test}}_{{/each}}each"
+			//"not_with": "not{{#with test}}_{{/with}}_with" //{{#with}} *always* renders non-inverse block
 		};
 
 		for (result in inv_staches) {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6128,16 +6128,32 @@ function makeTest(name, doc, mutation) {
 		});
 
 		var renderer = stache(
-			"{{#with first=person.first last=person.last}}" +
-				"<span>{{first}}</span>" +
-				"<span>{{last}}</span>" +
+			"{{#with firstName=person.first lastName=person.last}}" +
+				"<span>{{firstName}}</span>" +
+				"<span>{{lastName}}</span>" +
 			"{{/with}}"
 		);
 
 		var view = renderer(viewModel);
 
-		equal(view.children[0].firstChild.nodeValue, "John", "Got the first name");
-		equal(view.children[1].firstChild.nodeValue, "Gardner", "Got the last name");
+		equal(view.firstChild.firstChild.nodeValue, "John", "Got the first name");
+		equal(view.firstChild.nextSibling.firstChild.nodeValue, "Gardner", "Got the last name");
+
+		// second case: object AND hash values
+
+		renderer = stache(
+			"{{#with person firstName=person.first}}" +
+				"<span>{{firstName}}</span>" +
+				"<span>{{./last}}</span>" +
+			"{{/with}}"
+		);
+
+		view = renderer(viewModel);
+
+		equal(view.firstChild.firstChild.nodeValue, "John", "Got the first name");
+		equal(view.firstChild.nextSibling.firstChild.nodeValue, "Gardner", "Got the last name");
+
+
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!


### PR DESCRIPTION
With this PR we want to implement being able to use `{{#with first=person.first last=person.last}}` to change the scope.

So far only a test has been made.

For #274 