### PR TITLE
Update tests to ignore new warning

### DIFF
--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -3636,7 +3636,9 @@ function makeTest(name, doc, mutation) {
 				message = 'can-stache/src/expression.js: Unable to find helper "helpme".';
 
 			canDev.warn = function (text) {
-				equal(text, message, 'Got expected message logged.');
+				if(message === text){
+					equal(text, message, 'Got expected message logged.');
+				}
 			}
 
 			stache('<li>{{helpme name}}</li>')({
@@ -3651,7 +3653,9 @@ function makeTest(name, doc, mutation) {
 				message = 'can-stache/src/expression.js: Unable to find key or helper "user.name".';
 
 			canDev.warn = function (text) {
-				equal(text, message, 'Got expected message logged.');
+				if(text === message){
+					equal(text, message, 'Got expected message logged.');
+				}
 			}
 
 			stache('<li>{{user.name}}</li>')({
@@ -5531,8 +5535,11 @@ function makeTest(name, doc, mutation) {
 	if (System.env.indexOf('production') < 0) {
 		test("warn on unknown attributes (canjs/can-stache#139)", function(assert) {
 			var done = assert.async();
+			var message = "unknown attribute binding ($weirdattribute). Is can-stache-bindings imported?";
 			var warn = function(text) {
-				equal(text, "unknown attribute binding ($weirdattribute). Is can-stache-bindings imported?");
+				if(message === text){
+					equal(text, message);
+				}
 				done();
 			};
 			clone({
@@ -5791,7 +5798,9 @@ function makeTest(name, doc, mutation) {
 			expect(5);
 			var expr = /unknown attribute binding/;
 			var warn = function(text) {
-				ok(expr.test(text));
+				if(expr.test(text)){
+					ok(expr.test(text));
+				}
 			};
 			clone({
 				'can-stache-bindings': {},


### PR DESCRIPTION
Logging new warning can break these tests. By checking that the incoming string is the one we are looking for, we can avoid this.

[Some tests](https://github.com/canjs/can-stache/blob/master/test/stache-test.js#L204) simply check that `warn` was called, so it's still possible to have new warning cause a false positives.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
