### PR TITLE
Warn when Stache tokens are used at the top level

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -395,6 +395,12 @@ function stache (template) {
 				}
 			}
 			else {
+				//!steal-remove-start
+				if(mode !== "/" && state.sectionElementStack.length === 0) {
+					dev.warn("Stache tokens at the top level reduce rendering performance; {{" + text + "}} should be contained in an HTML element.");
+				}
+				//!steal-remove-end
+
 				makeRendererAndUpdateSection( state.textContentOnly || section, mode, expression );
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "can-event": "^3.6.0",
     "can-list": "^3.2.0",
     "can-map": "^3.3.0",
+    "can-test-helpers": "^1.0.0",
     "can-vdom": "^3.1.0",
     "jshint": "^2.9.4",
     "steal": "^1.0.5",

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6173,6 +6173,19 @@ function makeTest(name, doc, mutation) {
 
 	});
 
+	devHelpers.devOnlyTest("Warn when the top level element is a Stache section without enclosing HTML (#202)", function() {
+		var regex = /top level.*performance/;
+		var teardown = devHelpers.willWarn(regex);
+		
+		stache("<p>{{#if foo}}<p>{{bar}}</p>{{/if}}</p>");  // from here down should not warn
+		stache("<p {{#if foo}}{{bar}}{{/if}}>{{baz}}</p>");
+		QUnit.equal(teardown(), 0, "Top-level warning was not called in inappropriate cases");
+
+		teardown = devHelpers.willWarn(regex);
+		stache("{{#if foo}}<p>{{bar}}</p>{{/if}}");  // this one should warn
+		QUnit.equal(teardown(), 1, "Top-level warning was called in appropriate case");
+	})
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5506,37 +5506,35 @@ function makeTest(name, doc, mutation) {
 		}
 	});
 
-	devHelpers.devOnlyTest("warn on missmatched tag (canjs/canjs#1476)", function() {
-		var makeWarnChecks = function(input, texts) {
-			var count = 0;
-			var _warn = canDev.warn;
-			canDev.warn = function(text) {
-				equal(text, texts[count++]);
-			};
+	devHelpers.devOnlyTest("warn on mismatched tag (canjs/canjs#1476)", function() {
+		
+		var expectedMessages = [
+			"unexpected closing tag {{/foo}} expected {{/if}}",
+			"unexpected closing tag {{/foo}} expected {{/if}}",
+			"unexpected closing tag {{/foo}} expected {{/call}}"
+		];
 
-			stache(input);
-
-			equal(count, texts.length);
-
-			canDev.warn = _warn;
-		};
+		var teardown = devHelpers.willWarn(/unexpected closing tag/, function(message, matches) {
+			if(matches) {
+				if(expectedMessages.length < 1) {
+					QUnit.ok(false, "Unexpected warning trigger: " + message);
+				}
+				QUnit.equal(message, expectedMessages.shift(), message);
+			}
+		});
 
 		// Fails
-		makeWarnChecks("{{#if someCondition}}...{{/foo}}", [
-			"unexpected closing tag {{/foo}} expected {{/if}}"
-		]);
-		makeWarnChecks("{{^if someCondition}}...{{/foo}}", [
-			"unexpected closing tag {{/foo}} expected {{/if}}"
-		]);
-		makeWarnChecks("{{#call()}}...{{/foo}}", [
-			"unexpected closing tag {{/foo}} expected {{/call}}"
-		]);
+		stache("{{#if someCondition}}...{{/foo}});");
+		stache("{{^if someCondition}}...{{/foo}}");
+		stache("{{#call()}}...{{/foo}}");
 
 		// Successes
-		makeWarnChecks("{{#if}}...{{/}}", []);
-		makeWarnChecks("{{#if someCondition}}...{{/if}}", []);
-		makeWarnChecks("{{^if someCondition}}...{{/if}}", []);
-		makeWarnChecks("{{#call()}}...{{/call}}", []);
+		stache("{{#if}}...{{/}}");
+		stache("{{#if someCondition}}...{{/if}}");
+		stache("{{^if someCondition}}...{{/if}}");
+		stache("{{#call()}}...{{/call}}");
+
+		QUnit.equal(teardown(), 3, "Three warning messages generated");
 	});
 
 	devHelpers.devOnlyTest("warn on unknown attributes (canjs/can-stache#139)", function(assert) {


### PR DESCRIPTION
Fixes #202, but this had to include the commits from #307 for #302 because it depended on the new warnings helpers.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
