### PR TITLE
Resolves #300: Update each helper to use hash expressions

### DIFF
--- a/docs/helpers/each.md
+++ b/docs/helpers/each.md
@@ -16,7 +16,7 @@ is falsey or an empty list, render `INVERSE`.
 {{/each}}
 ```
 
-@param {can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/hash} EXPRESSION An
+@param {can-stache/expressions/key-lookup|can-stache/expressions/call} EXPRESSION An
 expression that typically returns a list like data structure.
 
 If the value of the EXPRESSION is a [can-define/list/list] or [can-list], the resulting HTML is updated when the list changes. When a change in the list happens, only the minimum amount of DOM
@@ -26,6 +26,31 @@ will be performed, which also will perform a minimal set of updates. The [can-st
 If the value of the key is an object, `FN` will be
 called for each property on the object. The [can-stache/keys/special special %key key]
 is available within `FN`.
+
+@param {can-stache.sectionRenderer} FN A subsection that will be rendered with each
+item in `EXPRESSION` or property value in `EXPRESSION`.
+
+@param {can-stache.sectionRenderer} [INVERSE] An optional subsection that will be rendered
+if `EXPRESSION` is falsey or an empty list or object.
+
+@signature `{{#each EXPRESSION HASH_EXPRESSION}}FN{{else}}INVERSE{{/each}}`
+
+Like a normal `{{#each EXPRESSION}}`, but uses [can-stache/expressions/hash] to
+add the current `value`, `key`, or `index` to the current scope.
+
+```
+{{#each todos todo=value num=index}}
+    <li data-index="{{num}}">{{todo.name}}</li>
+{{/each}}
+```
+
+@param {can-stache/expressions/key-lookup|can-stache/expressions/call} EXPRESSION An
+expression that returns a list or object like data structure.
+
+@param {can-stache/expressions/hash} HASH_EXPRESSION A hash expression that aliases special properties for each iteration:
+- `value`: The current value
+- `key`: The key of the current object item
+- `index`: The index of the current array item
 
 @param {can-stache.sectionRenderer} FN A subsection that will be rendered with each
 item in `EXPRESSION` or property value in `EXPRESSION`.

--- a/docs/helpers/each.md
+++ b/docs/helpers/each.md
@@ -1,6 +1,8 @@
 @function can-stache.helpers.each {{#each expression}}
 @parent can-stache.htags 5
 
+@deprecated {4.0} The `as` keyword signature, `{{#each EXPRESSION as KEY}}FN{{else}}INVERSE{{/each}}`, is deprecated in favor of [can-stache/expressions/hash].
+
 @signature `{{#each EXPRESSION}}FN{{else}}INVERSE{{/each}}`
 
 Render `FN` for each item in `EXPRESSION`'s return value.  If `EXPRESSION`
@@ -14,7 +16,7 @@ is falsey or an empty list, render `INVERSE`.
 {{/each}}
 ```
 
-@param {can-stache/expressions/key-lookup|can-stache/expressions/call} EXPRESSION An
+@param {can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/hash} EXPRESSION An
 expression that typically returns a list like data structure.
 
 If the value of the EXPRESSION is a [can-define/list/list] or [can-list], the resulting HTML is updated when the list changes. When a change in the list happens, only the minimum amount of DOM

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -38,7 +38,6 @@ var resolveHash = function(hash){
 
 var helpers = {
 	"each": function(items) {
-		// XXX
 		var args = [].slice.call(arguments),
 			options = args.pop(),
 			argsLen = args.length,
@@ -52,7 +51,7 @@ var helpers = {
 
 		if (argsLen === 2 || (argsLen === 3 && argExprs[1].key === 'as')) {
 			//!steal-remove-start
-			dev.warn('Using the `as` keyword is deprecated in favor of hash expressions. https://canjs.com/doc/can-stache.helpers.each.html');
+			dev.warn('can-stache: Using the `as` keyword is deprecated in favor of hash expressions. https://canjs.com/doc/can-stache.helpers.each.html');
 			//!steal-remove-end
 
 			asVariable = args[argsLen - 1];
@@ -91,6 +90,9 @@ var helpers = {
 
 					if (asVariable) {
 						aliases[asVariable] = item;
+						//!steal-remove-start
+						dev.warn('can-stache: Use `{{#each items item=value}}` instead of `{{#each items as item}}`.');
+						//!steal-remove-end
 					}
 
 					if (!isEmptyObject(hashOptions)) {
@@ -126,6 +128,18 @@ var helpers = {
 				};
 				if (asVariable) {
 					aliases[asVariable] = value;
+					//!steal-remove-start
+					dev.warn('can-stache: Use `{{#each items item=value itemKey=key}}` instead of `{{#each items as item}}`.');
+					//!steal-remove-end
+				}
+
+				if (!isEmptyObject(hashOptions)) {
+					if (hashOptions.value) {
+						aliases[hashOptions.value] = value;
+					}
+					if (hashOptions.key) {
+						aliases[hashOptions.key] = key;
+					}
 				}
 				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(value)));
 			});

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -38,21 +38,36 @@ var resolveHash = function(hash){
 
 var helpers = {
 	"each": function(items) {
+		// XXX
 		var args = [].slice.call(arguments),
 			options = args.pop(),
 			argsLen = args.length,
 			argExprs = options.exprData.argExprs,
+			hashExprs = options.exprData.hashExprs,
 			resolved = resolve(items),
 			asVariable,
+			hashOptions,
 			aliases,
 			key;
 
 		if (argsLen === 2 || (argsLen === 3 && argExprs[1].key === 'as')) {
+			//!steal-remove-start
+			dev.warn('Using the `as` keyword is deprecated in favor of hash expressions. https://canjs.com/doc/can-stache.helpers.each.html');
+			//!steal-remove-end
+
 			asVariable = args[argsLen - 1];
 
 			if (typeof asVariable !== 'string') {
 				asVariable = argExprs[argsLen - 1].key;
 			}
+		}
+
+		// Check if using hash
+		if (!isEmptyObject(hashExprs)) {
+			hashOptions = {};
+			each(hashExprs, function (exprs, key) {
+				hashOptions[exprs.key] = key;
+			})
 		}
 
 		if ((
@@ -76,6 +91,15 @@ var helpers = {
 
 					if (asVariable) {
 						aliases[asVariable] = item;
+					}
+
+					if (!isEmptyObject(hashOptions)) {
+						if (hashOptions.value) {
+							aliases[hashOptions.value] = item;
+						}
+						if (hashOptions.index) {
+							aliases[hashOptions.index] = index;
+						}
 					}
 
 					return options.fn(options.scope.add(aliases, { notContext: true }).add(item), options.options, parentNodeList);

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -50,15 +50,15 @@ var helpers = {
 			key;
 
 		if (argsLen === 2 || (argsLen === 3 && argExprs[1].key === 'as')) {
-			//!steal-remove-start
-			dev.warn('can-stache: Using the `as` keyword is deprecated in favor of hash expressions. https://canjs.com/doc/can-stache.helpers.each.html');
-			//!steal-remove-end
-
 			asVariable = args[argsLen - 1];
 
 			if (typeof asVariable !== 'string') {
 				asVariable = argExprs[argsLen - 1].key;
 			}
+			//!steal-remove-start
+			dev.warn('can-stache: Using the `as` keyword is deprecated in favor of hash expressions. https://canjs.com/doc/can-stache.helpers.each.html');
+			dev.warn('can-stache: Do not use `{{#' + options.nodeList.expression + '}}`, instead use `{{#' + options.nodeList.expression.split(' ')[0] + ' ' + options.nodeList.expression.split(' ')[1] + ' ' + asVariable + '=value}}`');
+			//!steal-remove-end
 		}
 
 		// Check if using hash
@@ -90,9 +90,6 @@ var helpers = {
 
 					if (asVariable) {
 						aliases[asVariable] = item;
-						//!steal-remove-start
-						dev.warn('can-stache: Use `{{#each items item=value}}` instead of `{{#each items as item}}`.');
-						//!steal-remove-end
 					}
 
 					if (!isEmptyObject(hashOptions)) {
@@ -128,9 +125,6 @@ var helpers = {
 				};
 				if (asVariable) {
 					aliases[asVariable] = value;
-					//!steal-remove-start
-					dev.warn('can-stache: Use `{{#each items item=value itemKey=key}}` instead of `{{#each items as item}}`.');
-					//!steal-remove-end
 				}
 
 				if (!isEmptyObject(hashOptions)) {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6201,7 +6201,7 @@ function makeTest(name, doc, mutation) {
 		equal(view.firstChild.nextSibling.firstChild.firstChild.nodeValue, "John", "Got aliased value");
 	});
 
-	test("using as keyword with each throws deprecation warning #300", function () {
+	test("using as keyword with each throws deprecation warning with link to docs #300", function () {
 		var viewModel = new DefineMap({
 			people: [{
 				first: "John",
@@ -6209,14 +6209,9 @@ function makeTest(name, doc, mutation) {
 			}]
 		});
 
-		var checkFirstWarnCall = testHelpers.dev.willWarn("can-stache: Using the `as` keyword is deprecated in favor of hash expressions. https://canjs.com/doc/can-stache.helpers.each.html", function (message, matched) {
+		var checkWarnCall = testHelpers.dev.willWarn("can-stache: Using the `as` keyword is deprecated in favor of hash expressions. https://canjs.com/doc/can-stache.helpers.each.html", function (message, matched) {
 			if (matched) {
-				ok(true, "Warning message properly set")
-			}
-		});
-		var checkSecondWarnCall = testHelpers.dev.willWarn("can-stache: Use `{{#each items item=value}}` instead of `{{#each items as item}}`.", function (message, matched) {
-			if (matched) {
-				ok(true, "Warning message properly set")
+				ok(true, "First warning message properly set");
 			}
 		});
 
@@ -6228,8 +6223,32 @@ function makeTest(name, doc, mutation) {
 		);
 
 		renderer(viewModel);
-		checkFirstWarnCall();
-		checkSecondWarnCall();
+		checkWarnCall();
+	});
+
+	test("using as keyword with each throws deprecation warning helper #300", function () {
+		var viewModel = new DefineMap({
+			people: [{
+				first: "John",
+				last: "Gardner"
+			}]
+		});
+
+		var checkWarnCall = testHelpers.dev.willWarn("can-stache: Do not use `{{#each people as person}}`, instead use `{{#each people person=value}}`", function (message, matched) {
+			if (matched) {
+				ok(true, "Second warning message properly set");
+			}
+		});
+
+		var renderer = stache(
+			"{{#each people as person}}" +
+				"<span>{{person.first}}</span>" +
+				"<span>{{person.last}}</span>" +
+			"{{/with}}"
+		);
+
+		renderer(viewModel);
+		checkWarnCall();
 	});
 
 	test("can assign hash using each on an iterable map #300", function () {
@@ -6250,36 +6269,6 @@ function makeTest(name, doc, mutation) {
 
 		equal(view.firstChild.firstChild.nodeValue, "isJSCool", "Got the key");
 		equal(view.firstChild.lastChild.nodeValue, "yep", "Got aliased value");
-	});
-
-	test("using each `as` on an iterable map throws deprecation warning #300", function () {
-		var viewModel = new DefineMap({
-			flags: {
-				isJSCool: "yep",
-				canJS: "yep"
-			}
-		});
-
-		var checkFirstWarnCall = testHelpers.dev.willWarn("can-stache: Using the `as` keyword is deprecated in favor of hash expressions. https://canjs.com/doc/can-stache.helpers.each.html", function (message, matched) {
-			if (matched) {
-				ok(true, "Warning message properly set")
-			}
-		});
-		var checkSecondWarnCall = testHelpers.dev.willWarn("can-stache: Use `{{#each items item=value itemKey=key}}` instead of `{{#each items as item}}`.", function (message, matched) {
-			if (matched) {
-				ok(true, "Warning message properly set")
-			}
-		});
-
-		var renderer = stache(
-			"{{#each flags as flag}}" +
-				"<span>{{%key}}: {{flag}}</span>" +
-			"{{/each}}"
-		);
-
-		renderer(viewModel);
-		checkFirstWarnCall();
-		checkSecondWarnCall();
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -32,6 +32,7 @@ var string = require('can-util/js/string/string');
 var makeArray = require('can-util/js/make-array/make-array');
 var joinURIs = require('can-util/js/join-uris/join-uris');
 var getBaseURL = require('can-util/js/base-url/base-url');
+var testHelpers = require('can-test-helpers');
 
 var browserDoc = DOCUMENT();
 var mutationObserver = MUTATION_OBSERVER();
@@ -5994,7 +5995,7 @@ function makeTest(name, doc, mutation) {
 				}
 			}
 		});
-		
+
 		var renderer = stache(
 			"{{#child}}" +
 				"<span>" +
@@ -6023,7 +6024,7 @@ function makeTest(name, doc, mutation) {
 				}
 			}
 		});
-		
+
 		var renderer = stache(
 			"{{#child}}" +
 				"<span>" +
@@ -6052,7 +6053,7 @@ function makeTest(name, doc, mutation) {
 				}
 			}
 		});
-		
+
 		var renderer = stache(
 			"{{<somePartial}}" +
 				"foo" +
@@ -6085,7 +6086,7 @@ function makeTest(name, doc, mutation) {
 				}
 			}
 		});
-		
+
 		var renderer = stache(
 			"{{#child}}" +
 				"<span>" +
@@ -6101,7 +6102,7 @@ function makeTest(name, doc, mutation) {
 
 		equal(view.firstChild.firstChild.nodeValue, "1", "It got the passed scope");
 	});
-	
+
 	test("newline is a valid special tag white space", function() {
 		var renderer = stache('<div\n\t{{#unless ./hideIt}}\n\t\thidden\n\t{{/unless}}\n>peekaboo</div>');
 		var html = renderer({ hideIt: true });
@@ -6173,7 +6174,58 @@ function makeTest(name, doc, mutation) {
 
 	});
 
+	test("can assign hash using each #300", function () {
+		var viewModel = new DefineMap({
+			people: [{
+				first: "John",
+				last: "Gardner"
+			}, {
+				first: "Juan",
+				last: "Orozco"
+			}, {
+				first: "B",
+				last: "Rad"
+			}]
+		});
+
+		var renderer = stache(
+			"{{#each people person=value num=index}}" +
+				"<div class=\"person\" data-index=\"{{num}}\"><span>{{person.first}}</span>" +
+				"<span>{{person.last}}</span></div>" +
+			"{{/each}}"
+		);
+
+		var view = renderer(viewModel);
+
+		equal(view.lastChild.getAttribute('data-index'), "2", "Got the index");
+		equal(view.firstChild.nextSibling.firstChild.firstChild.nodeValue, "John", "Got aliased value");
+	});
+
+	test("using as keyword with each throws deprecation warning #300", function () {
+		var viewModel = new DefineMap({
+			people: [{
+				first: "John",
+				last: "Gardner"
+			}]
+		});
+
+		var checkWarnCall = testHelpers.dev.willWarn("Using the `as` keyword is deprecated in favor of hash expressions. https://canjs.com/doc/can-stache.helpers.each.html", function (message, matched) {
+			if (matched) {
+				ok(true, "Warning message properly set")
+			}
+		});
+
+		var renderer = stache(
+			"{{#each people as person}}" +
+				"<span>{{person.first}}</span>" +
+				"<span>{{person.last}}</span>" +
+			"{{/with}}"
+		);
+
+		var view = renderer(viewModel);
+		checkWarnCall();
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }
-


### PR DESCRIPTION
Resolves #300 

The `{{#each}}` helper now allows using hash expressions. Using the `as` keyword is deprecated, a warning was added with a link to documentation.

- helpers/core.js: Modified each helper to accept hash expressions
- Updated tests
- Updated docs

