### PR TITLE
deprecating *variable and *self and documenting scope (templateContext)

### DIFF
--- a/docs/keys/scope.md
+++ b/docs/keys/scope.md
@@ -1,0 +1,11 @@
+@typedef {String} can-stache/keys/scope scope
+@parent can-stache/keys
+@description The template context
+
+@signature `scope.vars`
+
+Variables local to the template. See [can-stache/keys/scope/scope.vars] for details.
+
+@signature `scope.view`
+
+The current template. See [can-stache/keys/scope/scope.view] for details.

--- a/docs/keys/scope.vars.md
+++ b/docs/keys/scope.vars.md
@@ -1,0 +1,56 @@
+@typedef {String} can-stache/keys/scope/scope.vars scope.vars
+@parent can-stache/keys/scope
+@description Used to reference variables specific to the template context
+
+@signature `scope.vars`
+
+A placeholder for a value that is local to the template.
+
+```
+<drivers-licenses selected:to="scope.vars.selectedDriver"/>
+<edit-driver driver:from="scope.vars.selectedDriver"/>
+```
+
+@body
+
+## Use
+
+Template variables are often used to pass data between
+components. `<component-a>` exports its `propA` value to the
+template variable `scope.vars.variable`.  This is, in turn, used to update
+the value of `propB` in `<component-b>`.
+
+```
+<component-a propA:to="scope.vars.variable"/>
+<component-b propB:from="scope.vars.variable"/>
+```
+
+Template variables are global to the template. Similar to JavaScript `var`
+variables, template variables do not have block level scope.  The following
+does not work:
+
+```
+{{#each something}}
+	<component-a propA:to="scope.vars.variable"/>
+	<component-b propB:from="scope.vars.variable"/>
+{{/each}}
+```
+
+To work around this, an `localContext` helper could be created as follows:
+
+```
+stache.regsiterHelper("localContext", function(options){
+  return options.fn(new Map());
+});
+```
+
+And used like:
+
+```
+{{#each something}}
+	{{#localContext}}
+	  <component-a propA:to="./variable"/>
+	  <component-b propB:from="./variable"/>
+	{{/localContext}}
+{{/each}}
+```

--- a/docs/keys/scope.view.md
+++ b/docs/keys/scope.view.md
@@ -1,16 +1,14 @@
-@typedef {String} can-stache/keys/variable/self *self
-@parent can-stache/keys
-@description Used to reference the current template and recursively render it
+@typedef {String} can-stache/keys/scope/scope.view scope.view
+@parent can-stache/keys/scope
+@description Used to reference the current template
 
-@deprecated {4.0} `{{>*self}}` is deprecated in favor of [can-stache/keys/scope/scope.view `{{>scope.view}}`]
+@signature `scope.view`
 
-@signature `{{>*self}}`
-
-The entirety of the current template is always stored as a [can-stache.tags.named-partial named partial] `*self`
+The entirety of the current template is always stored as a [can-stache.tags.named-partial named partial] `scope.view`
 
 ```
 <div>
-	{{>*self}}
+	{{>scope.view}}
 </div>
 ```
 
@@ -18,8 +16,8 @@ The entirety of the current template is always stored as a [can-stache.tags.name
 
 ## Use
 
-This can be used to recursively render a template given a stop condition. 
-Note that we use a key expression to set local scope. Also note it is 
+This can be used to recursively render a template given a stop condition.
+Note that we use a key expression to set local scope. Also note it is
 a dot slash on the child key expression.
 The dot slash prevents walking up the scope. See [can-stache.tags.named-partial#TooMuchRecursion Too Much Recursion] for more details.
 
@@ -38,7 +36,7 @@ var renderer = stache(`
 	<span>{{name}}</span>
 	{{#./child}}
 		<div>
-			{{>*self}}
+			{{>scope.view}}
 		</div>
 	{{/child}}
 `);
@@ -78,7 +76,7 @@ var renderer = stache(`
 	<p>{{hasArms}}</p>
 	{{#./child}}
 		<div>
-			{{>*self}}
+			{{>scope.view}}
 		</div>
 	{{/child}}
 `);
@@ -100,4 +98,4 @@ The view variable will be the document fragment:
 </div>
 ```
 
-For a more detailed explaination of using partials recursively see [can-stache.tags.named-partial#TooMuchRecursion Too Much Recursion]
+For a more detailed explanation of using partials recursively see [can-stache.tags.named-partial#TooMuchRecursion Too Much Recursion]

--- a/docs/keys/variable.md
+++ b/docs/keys/variable.md
@@ -1,7 +1,9 @@
 @typedef {String} can-stache/keys/variable *variable
 @parent can-stache/keys
+@description Store a variable local to the template.
 
-Store a variable local to the template.
+@deprecated {4.0} `{{*variable}}` is deprecated in favor of [can-stache/keys/scope/scope.vars `{{scope.vars.variable}}`]
+
 
 @signature `*variable`
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "can-view-live": "^3.2.0",
     "can-view-nodelist": "^3.1.0",
     "can-view-parser": "^3.6.0",
-    "can-view-scope": "^3.3.1",
+    "can-view-scope": "^3.4.2",
     "can-view-target": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
These were actually deprecated in https://github.com/canjs/can-view-scope/releases/tag/v3.4.0, but are now officially deprecated in the docs.