### PR TITLE
Fixed issue breaking hash expressions with plain objects

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -137,12 +137,32 @@ var helpers = {
 			});
 
 			return options.stringOnly ? result.join('') : result;
-		} else if(Array.isArray(expr) || expr instanceof Object) {
+		} else if(Array.isArray(expr)) {
+			result = [];
+			each(expr, function(value, index){
+				aliases = {
+					"%index": index,
+					"@index": index
+				};
+				if (asVariable) {
+					aliases[asVariable] = value;
+				}
+
+				if (!isEmptyObject(hashOptions)) {
+					if (hashOptions.value) {
+						aliases[hashOptions.value] = value;
+					}
+					if (hashOptions.index) {
+						aliases[hashOptions.index] = index;
+					}
+				}
+				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(value)));
+			});
+			return options.stringOnly ? result.join('') : result;
+		} else if(expr instanceof Object) {
 			result = [];
 			each(expr, function(value, key){
 				aliases = {
-					"%index": key,
-					"@index": key,
 					"%key": key,
 					"@key": key
 				};
@@ -156,9 +176,6 @@ var helpers = {
 					}
 					if (hashOptions.key) {
 						aliases[hashOptions.key] = key;
-					}
-					if (hashOptions.index) {
-						aliases[hashOptions.index] = key;
 					}
 				}
 				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(value)));

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -114,15 +114,13 @@ var helpers = {
 		var expr = resolved,
 			result;
 
-		if ( !! expr && utils.isArrayLike(expr)) {
-			result = utils.getItemsFragContent(expr, options, options.scope, asVariable);
-			return options.stringOnly ? result.join('') : result;
-		}
-		else if(isIterable(expr)) {
+		if(isIterable(expr)) {
 			result = [];
 			each(expr, function(value, key){
 				aliases = {
-					"%key": key
+					"%key": key,
+					"%index": key,
+					"@index": key
 				};
 				if (asVariable) {
 					aliases[asVariable] = value;
@@ -165,6 +163,14 @@ var helpers = {
 				};
 				if (asVariable) {
 					aliases[asVariable] = expr[key];
+				}
+				if (!isEmptyObject(hashOptions)) {
+					if (hashOptions.value) {
+						aliases[hashOptions.value] = expr[key];
+					}
+					if (hashOptions.key) {
+						aliases[hashOptions.key] = key;
+					}
 				}
 				result.push(options.fn(options.scope.add(aliases, { notContext: true }).add(expr[key])));
 			}

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -36,7 +36,6 @@ var testHelpers = require('can-test-helpers');
 var canLog = require('can-log');
 var debug = require('../helpers/-debugger');
 var helpersCore = require('can-stache/helpers/core');
-var utils = require('../src/utils');
 
 var browserDoc = DOCUMENT();
 var mutationObserver = MUTATION_OBSERVER();
@@ -6595,36 +6594,21 @@ function makeTest(name, doc, mutation) {
 		equal(warn2(), 0);
 	});
 
-	test('#each with call expression and plain array should not use utils.getItemsFragContent', function(){
-		var getItemsFragContent = utils.getItemsFragContent;
-		var callCount = 0;
-		utils.getItemsFragContent = function(){
-			callCount++;
-		};
-
-		var list = ['foo', 'bar', 'baz'];
-		var template = stache('{{#each(this)}}{{this}}{{/each}}');
-		template(list);
-
-		equal(callCount, 0);
-
-		utils.getItemsFragContent = getItemsFragContent;
-	});
 
 	test('#each with call expression and arrays should work with hash expressions', function(){
 		var list = ['foo', 'bar', 'baz'];
-		var template = stache('{{#each(this, item=value)}}{{item}}{{/each}}');
+		var template = stache('{{#each(this, item=value, itemIndex=index)}}{{itemIndex}}:{{item}}{{/each}}');
 		var div = doc.createElement('div');
 		var frag = template(list);
 
 		div.appendChild(frag);
 
-		equal(innerHTML(div), list.join(''));
+		equal(innerHTML(div), '0:foo1:bar2:baz');
 	});
 
 	test('#each with call expression and objects should work with hash expressions', function(){
 		var map = {'foo': 'bar', 'baz': 'qux'};
-		var template = stache('{{#each(this, prefix=key item=value)}}{{prefix}}:{{item}}{{/each}}');
+		var template = stache('{{#each(this, itemKey=key itemValue=value)}}{{itemKey}}:{{itemValue}}{{/each}}');
 		var div = doc.createElement('div');
 		var frag = template(map);
 


### PR DESCRIPTION
When passing `Array`s to each, they were delegated to `utils.getItemsFragContent`, which does not support hash expression and should not be used in this case.

When passing `Object`s to each, the last case of `expr instanceof Object` handles the iteration, which also did not support hash expressions.

Closes #325

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
