### PR TITLE
correctly setting scope.index and deprecating %index/@index with arays

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -204,7 +204,7 @@ var helpers = {
 			result = [];
 			each(expr, function(value, index){
 				var templateContext = options.scope.getTemplateContext()._context;
-				canReflect.setKeyValue(templateContext, 'key', key);
+				canReflect.setKeyValue(templateContext, 'index', index);
 
 				aliases = {
 					"%index": index,
@@ -212,29 +212,29 @@ var helpers = {
 				};
 
 				//!steal-remove-start
-				Object.defineProperty(aliases, '%key', {
+				Object.defineProperty(aliases, '%index', {
 					get: function() {
 						var filename = canReflect.getKeyValue(templateContext, 'filename');
 						var lineNumber = canReflect.getKeyValue(templateContext, 'lineNumber');
 						dev.warn(
 							(filename ? filename + ':' : '') +
 							(lineNumber ? lineNumber + ': ' : '') +
-							'%key is deprecated. Use scope.key instead.'
+							'%index is deprecated. Use scope.index instead.'
 						);
-						return key;
+						return index;
 					}
 				});
 
-				Object.defineProperty(aliases, '@key', {
+				Object.defineProperty(aliases, '@index', {
 					get: function() {
 						var filename = canReflect.getKeyValue(templateContext, 'filename');
 						var lineNumber = canReflect.getKeyValue(templateContext, 'lineNumber');
 						dev.warn(
 							(filename ? filename + ':' : '') +
 							(lineNumber ? lineNumber + ': ' : '') +
-							'@key is deprecated. Use scope.key instead.'
+							'@index is deprecated. Use scope.index instead.'
 						);
-						return key;
+						return index;
 					}
 				});
 				//!steal-remove-end

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6633,9 +6633,9 @@ function makeTest(name, doc, mutation) {
 	});
 
 	QUnit.test("using scope.index works when using #each with arrays", function() {
-		var data = new DefineMap({
+		var data = {
 			itemsArray: [ "zero", "one", "two" ]
-		});
+		};
 
 		var renderer = stache("index.stache",
 			"<ul>\n" +
@@ -6659,9 +6659,9 @@ function makeTest(name, doc, mutation) {
 	testHelpers.dev.devOnlyTest("using %index shows a deprecation warning when using #each with arrays", function() {
 		var teardown = testHelpers.dev.willWarn("index.stache:2: %index is deprecated. Use scope.index instead.");
 
-		var data = new DefineMap({
+		var data = {
 			itemsArray: [ "zero", "one", "two" ]
-		});
+		};
 
 		var renderer = stache("index.stache",
 			"<ul>\n" +
@@ -6687,9 +6687,9 @@ function makeTest(name, doc, mutation) {
 	testHelpers.dev.devOnlyTest("using @index shows a deprecation warning when using #each with arrays", function() {
 		var teardown = testHelpers.dev.willWarn("index.stache:2: @index is deprecated. Use scope.index instead.");
 
-		var data = new DefineMap({
+		var data = {
 			itemsArray: [ "zero", "one", "two" ]
-		});
+		};
 
 		var renderer = stache("index.stache",
 			"<ul>\n" +


### PR DESCRIPTION
closes https://github.com/canjs/can-stache/issues/356.