### PR TITLE
Fixed a bug causing erroneous warnings when expression uses brackets

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -100,7 +100,7 @@ function stache (filename, template) {
 				if(section instanceof HTMLSectionBuilder) {
 					//!steal-remove-start
 					var last = state.sectionElementStack[state.sectionElementStack.length - 1];
-					if (last.type === "section" && stache !== "" && stache !== last.tag) {
+					if (last.tag && last.type === "section" && stache !== "" && stache !== last.tag) {
 						if (filename) {
 							dev.warn(filename + ":" + lineNo + ": unexpected closing tag {{/" + stache + "}} expected {{/" + last.tag + "}}");
 						}

--- a/expressions/bracket.js
+++ b/expressions/bracket.js
@@ -19,7 +19,7 @@ Bracket.prototype.value = function (scope, helpers) {
 
 Bracket.prototype.closingTag = function() {
 	//!steal-remove-start
-	return this[canSymbol.for('can-stache.originalKey')];
+	return this[canSymbol.for('can-stache.originalKey')] || '';
 	//!steal-remove-end
 };
 

--- a/expressions/bracket.js
+++ b/expressions/bracket.js
@@ -1,14 +1,26 @@
+//!steal-remove-start
+var canSymbol = require('can-symbol');
+//!steal-remove-end
 var expressionHelpers = require("../src/expression-helpers");
 
 // ### Bracket
 // For accessing properties using bracket notation like `foo[bar]`
-var Bracket = function (key, root) {
+var Bracket = function (key, root, originalKey) {
 	this.root = root;
 	this.key = key;
+	//!steal-remove-start
+	this[canSymbol.for("can-stache.originalKey")] = originalKey;
+	//!steal-remove-end
 };
 Bracket.prototype.value = function (scope, helpers) {
 	var root = this.root ? this.root.value(scope, helpers) : scope.peek('.');
 	return expressionHelpers.getObservableValue_fromDynamicKey_fromObservable(this.key.value(scope, helpers), root, scope, helpers, {});
+};
+
+Bracket.prototype.closingTag = function() {
+	//!steal-remove-start
+	return this[canSymbol.for('can-stache.originalKey')];
+	//!steal-remove-end
 };
 
 module.exports = Bracket;

--- a/src/expression.js
+++ b/src/expression.js
@@ -468,7 +468,7 @@ var expression = {
 				} else if (top.type === "Lookup" || top.type === "Bracket") {
 					var bracket = {type: "Bracket", root: top};
 					//!steal-remove-start
-					canReflect.setKeyValue(bracket, canSymbol.for("can-stache.originalKey"), tokens.join('').trim());
+					canReflect.setKeyValue(bracket, canSymbol.for("can-stache.originalKey"), top.key);
 					//!steal-remove-end
 					stack.replaceTopAndPush(bracket);
 				} else if (top.type === "Call") {

--- a/src/expression.js
+++ b/src/expression.js
@@ -308,7 +308,10 @@ var expression = {
 		} else if (ast.type === "Bracket") {
 			return new Bracket(
 				this.hydrateAst(ast.children[0], options),
-				ast.root ? this.hydrateAst(ast.root, options) : undefined
+				ast.root ? this.hydrateAst(ast.root, options) : undefined,
+				//!steal-remove-start
+				ast[canSymbol.for("can-stache.originalKey")]
+				//!steal-remove-end
 			);
 		}
 	},
@@ -463,7 +466,11 @@ var expression = {
 				if (lastToken && (lastToken.type === "Call" || lastToken.type === "Bracket"  )  ) {
 					stack.replaceTopAndPush({type: "Bracket", root: lastToken});
 				} else if (top.type === "Lookup" || top.type === "Bracket") {
-					stack.replaceTopAndPush({type: "Bracket", root: top});
+					var bracket = {type: "Bracket", root: top};
+					//!steal-remove-start
+					canReflect.setKeyValue(bracket, canSymbol.for("can-stache.originalKey"), tokens.join('').trim());
+					//!steal-remove-end
+					stack.replaceTopAndPush(bracket);
 				} else if (top.type === "Call") {
 					stack.addToAndPush(["Call"], { type: "Bracket" });
 				} else if (top === " ") {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7062,6 +7062,22 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(innerHTML(div), "012345");
 	});
 
+	QUnit.test("section iteration of property using bracket notation should not warn about unexpected closing tag", function (){
+		var teardown = testHelpers.dev.willWarn(/unexpected closing tag/);
+
+		stache("{{#items['foo:bar']}}{{this}}{{/items['foo:bar']}}");
+
+		equal(teardown(), 0);
+	});
+
+	QUnit.test("section iteration of property using bracket notation should warn about unexpected closing tag", function (){
+		var teardown = testHelpers.dev.willWarn("1: unexpected closing tag {{/items}} expected {{/items['foo:bar']}}");
+
+		stache("{{#items['foo:bar']}}{{this}}{{/items}}");
+
+		equal(teardown(), 1);
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7062,7 +7062,7 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(innerHTML(div), "012345");
 	});
 
-	QUnit.test("section iteration of property using bracket notation should not warn about unexpected closing tag", function (){
+	testHelpers.dev.devOnlyTest("section iteration of property using bracket notation should not warn about unexpected closing tag", function (){
 		var teardown = testHelpers.dev.willWarn(/unexpected closing tag/);
 
 		stache("{{#items['foo:bar']}}{{this}}{{/items}}");
@@ -7070,7 +7070,7 @@ function makeTest(name, doc, mutation) {
 		equal(teardown(), 0);
 	});
 
-	QUnit.test("passing bracket notation to method should not warn about unexpected closing tag", function (){
+	testHelpers.dev.devOnlyTest("passing bracket notation to method should not warn about unexpected closing tag", function (){
 		var teardown = testHelpers.dev.willWarn(/unexpected closing tag/);
 
 		stache("{{#eq(items['foo:bar'], 'baz')}}qux{{/eq}}");
@@ -7078,7 +7078,7 @@ function makeTest(name, doc, mutation) {
 		equal(teardown(), 0);
 	});
 
-	QUnit.test("reading current scope with bracket notation should not warn about unexpected closing tag", function (){
+	testHelpers.dev.devOnlyTest("reading current scope with bracket notation should not warn about unexpected closing tag", function (){
 		var teardown = testHelpers.dev.willWarn(/unexpected closing tag/);
 
 		stache("{{#['foo:bar']}}qux{{/['foo:bar']}}");
@@ -7086,7 +7086,7 @@ function makeTest(name, doc, mutation) {
 		equal(teardown(), 0);
 	});
 
-	QUnit.test("section iteration of property using bracket notation should warn about unexpected closing tag", function (){
+	testHelpers.dev.devOnlyTest("section iteration of property using bracket notation should warn about unexpected closing tag", function (){
 		var teardown = testHelpers.dev.willWarn("1: unexpected closing tag {{/items['foo:bar']}} expected {{/items}}");
 
 		stache("{{#items['foo:bar']}}{{this}}{{/items['foo:bar']}}");

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7065,15 +7065,31 @@ function makeTest(name, doc, mutation) {
 	QUnit.test("section iteration of property using bracket notation should not warn about unexpected closing tag", function (){
 		var teardown = testHelpers.dev.willWarn(/unexpected closing tag/);
 
-		stache("{{#items['foo:bar']}}{{this}}{{/items['foo:bar']}}");
+		stache("{{#items['foo:bar']}}{{this}}{{/items}}");
+
+		equal(teardown(), 0);
+	});
+
+	QUnit.test("passing bracket notation to method should not warn about unexpected closing tag", function (){
+		var teardown = testHelpers.dev.willWarn(/unexpected closing tag/);
+
+		stache("{{#eq(items['foo:bar'], 'baz')}}qux{{/eq}}");
+
+		equal(teardown(), 0);
+	});
+
+	QUnit.test("reading current scope with bracket notation should not warn about unexpected closing tag", function (){
+		var teardown = testHelpers.dev.willWarn(/unexpected closing tag/);
+
+		stache("{{#['foo:bar']}}qux{{/['foo:bar']}}");
 
 		equal(teardown(), 0);
 	});
 
 	QUnit.test("section iteration of property using bracket notation should warn about unexpected closing tag", function (){
-		var teardown = testHelpers.dev.willWarn("1: unexpected closing tag {{/items}} expected {{/items['foo:bar']}}");
+		var teardown = testHelpers.dev.willWarn("1: unexpected closing tag {{/items['foo:bar']}} expected {{/items}}");
 
-		stache("{{#items['foo:bar']}}{{this}}{{/items}}");
+		stache("{{#items['foo:bar']}}{{this}}{{/items['foo:bar']}}");
 
 		equal(teardown(), 1);
 	});


### PR DESCRIPTION
Fixes canjs/can-view-parser#75

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
