### PR TITLE
Set lineNumber on the scope before passing it to viewCallbacks.tagHandler

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -270,6 +270,9 @@ function stache (filename, template) {
 					// Get the last element in the stack
 					var current = state.sectionElementStack[state.sectionElementStack.length - 1];
 					addAttributesCallback(oldNode, function(scope, options, parentNodeList){
+						//!steal-remove-start
+						scope.set('scope.lineNumber', lineNo);
+						//!steal-remove-end
 						viewCallbacks.tagHandler(this,tagName, {
 							scope: scope,
 							options: options,
@@ -320,6 +323,9 @@ function stache (filename, template) {
 						state.node.attributes = [];
 					}
 					state.node.attributes.push(function(scope, options, nodeList){
+						//!steal-remove-start
+						scope.set('scope.lineNumber', lineNo);
+						//!steal-remove-end
 						attrCallback(this,{
 							attributeName: attrName,
 							scope: scope,

--- a/can-stache.js
+++ b/can-stache.js
@@ -206,6 +206,9 @@ function stache (filename, template) {
 				section.add(state.node);
 				if(isCustomTag) {
 					addAttributesCallback(state.node, function(scope, options, parentNodeList){
+						//!steal-remove-start
+						scope.set('scope.lineNumber', lineNo);
+						//!steal-remove-end
 						viewCallbacks.tagHandler(this,tagName, {
 							scope: scope,
 							options: options,

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7086,6 +7086,41 @@ function makeTest(name, doc, mutation) {
 		equal(teardown(), 1);
 	});
 
+	testHelpers.dev.devOnlyTest("lineNumber should be set on the scope at 'end' before passing it to viewCallbacks.tagHandler (#373)", function (){
+		var tagHandler = viewCallbacks.tagHandler;
+
+		viewCallbacks.tagHandler = function (context, tagName, options){
+			equal(options.scope.peek('lineNumber'), 3);
+		}
+
+		stache("foo\nbar\n<cust-elem/>\nbaz")();
+
+		viewCallbacks.tagHandler = tagHandler;
+	});
+
+	testHelpers.dev.devOnlyTest("lineNumber should be set on the scope at 'close' before passing it to viewCallbacks.tagHandler (#373)", function (){
+		var tagHandler = viewCallbacks.tagHandler;
+
+		viewCallbacks.tagHandler = function (context, tagName, options){
+			equal(options.scope.peek('lineNumber'), 3);
+		}
+
+		stache("foo\nbar\n<cust-elem></cust-elem>\nbaz")();
+
+		viewCallbacks.tagHandler = tagHandler;
+	});
+
+	testHelpers.dev.devOnlyTest("lineNumber should be set on the scope at 'attrEnd' before passing it to viewCallbacks.tagHandler (#373)", function (){
+		viewCallbacks.attr(/[\w\.:]+:from$/, function (el, attrData){
+			equal(attrData.scope.peek('lineNumber'), 3);
+		});
+
+		stache("foo\nbar\n<div toProp:from=\"fromProp\"/></div>\nbaz")();
+
+		// Remove handler to prevent side effect of other tests from calling this assertion
+		viewCallbacks._regExpAttributes.splice(viewCallbacks._regExpAttributes.length - 1, 1);
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
Fixes #372

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
