### PR TITLE
not explicitly setting scope.root

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -425,9 +425,6 @@ function stache (filename, template) {
 		// allow the current renderer to be called with {{>scope.view}}
 		scope.set('scope.view', scopifiedRenderer);
 
-		// allow reading from the root context using {{scope.root.<whatever>}}
-		scope.set('scope.root', scope._context);
-
 		//!steal-remove-start
 		scope.set('scope.filename', section.filename);
 		//!steal-remove-end


### PR DESCRIPTION
this is now handled in can-view-scope.