### PR TITLE
Fix registerSimpleHelper deprecation warning

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -433,7 +433,7 @@ module.exports = {
 
 	registerSimpleHelper: function() {
 		//!steal-remove-start
-		dev.warn("stache.registerSimplePartial is deprecated. Use stache.addHelper instead.");
+		dev.warn("stache.registerSimpleHelper is deprecated. Use stache.addHelper instead.");
 		//!steal-remove-end
 
 		registerSimpleHelper.apply(this, arguments);

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7064,7 +7064,7 @@ function makeTest(name, doc, mutation) {
 	testHelpers.dev.devOnlyTest('deprecation warning shown for registerSimpleHelper', function() {
 		var template = stache('<div>{{simple "foo"}}</div>');
 
-		var teardown = testHelpers.dev.willWarn("stache.registerSimplePartial is deprecated. Use stache.addHelper instead.");
+		var teardown = testHelpers.dev.willWarn("stache.registerSimpleHelper is deprecated. Use stache.addHelper instead.");
 
 		stache.registerSimpleHelper('simple', function(str) {
 			QUnit.equal(str, "foo");


### PR DESCRIPTION
Warning shows 'registerSimplePartial' but should be 'registerSimpleHelper'.