### PR TITLE
Support can-template with no content

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -264,7 +264,9 @@ function stache (filename, template) {
 					// If we find a can-template we want to go back 2 in the stack to get it's inner content
 					// rather than the <can-template> element itself
 					var parent = state.sectionElementStack[state.sectionElementStack.length - 2];
-					parent.templates[oldNode.attrs.name] = makeRendererConvertScopes(renderer);
+					if (renderer) {// Only add the renderer if the template has content
+						parent.templates[oldNode.attrs.name] = makeRendererConvertScopes(renderer);
+					}
 					section.removeCurrentNode();
 				} else {
 					// Get the last element in the stack

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5581,6 +5581,23 @@ function makeTest(name, doc, mutation) {
 		frag = template({});
 	});
 
+	test("can-template works with no content (#418)", function() {
+		var frag;
+
+		var template = stache(
+			'<my-email>' +
+				'<can-template name="subject">' +
+				'</can-template>' +
+			'</my-email>');
+
+		viewCallbacks.tag("my-email", function(el, tagData){
+			QUnit.ok(tagData.templates, "has templates");
+			QUnit.notOk(tagData.templates.subject, 'no subject template');
+		});
+
+		frag = template({});
+	});
+
 	test("#each with arrays (#215)", function(){
 		var which = canCompute(false);
 		var a = {}, b = {}, c = {};


### PR DESCRIPTION
This fixes `<can-template>` so it can have no content.

Part of https://github.com/canjs/can-stache/issues/418