### PR TITLE
not warning on keys that are defined but are `undefined`

### DIFF
--- a/expressions/lookup.js
+++ b/expressions/lookup.js
@@ -24,7 +24,15 @@ Lookup.prototype.value = function(scope, readOptions){
 
 	//!steal-remove-start
 	if (typeof value.initialValue === 'undefined') {
-		dev.warn('can-stache/expressions/lookup.js: Unable to find key "' + this.key + '".');
+		// TODO - this should use canReflect.hasKey
+		var hasKeySymbol = canSymbol.for("can.hasKey");
+		var context = value.startingScope && value.startingScope._context;
+		var propDefined = context && context[hasKeySymbol] &&
+			context[hasKeySymbol](this.key);
+
+		if (!propDefined) {
+			dev.warn('can-stache/expressions/lookup.js: Unable to find key "' + this.key + '".');
+		}
 	}
 	//!steal-remove-end
 

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6648,6 +6648,24 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(scope.get("scope.lineNumber"), 1);
 	});
 
+	testHelpers.dev.devOnlyTest("should not warn for keys that exist but are `undefined` (#427)", function () {
+		var vm = {
+			_props: {
+				propWithoutValue: true
+			},
+			propWithoutValue: null
+		};
+		vm[canSymbol.for("can.hasKey")] = function(key) {
+			return this._props[key];
+		};
+
+		var teardown = testHelpers.dev.willWarn('can-stache/expressions/lookup.js: Unable to find key "propWithoutValue".');
+
+		stache('<li>{{propWithoutValue}}</li>')(vm);
+
+		QUnit.equal(teardown(), 0, 'did not get warning');
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
closes #427.