### PR TITLE
Update the dependencies for can-view-parser and can-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     "can-route": "^3.2.0",
     "can-stache-key": "^0.1.2",
     "can-symbol": "^1.0.0",
-    "can-util": "^3.10.6",
+    "can-util": "^3.10.12",
     "can-view-callbacks": "^3.2.0",
     "can-view-live": "^3.2.0",
     "can-view-nodelist": "^3.1.0",
-    "can-view-parser": "^3.6.0",
+    "can-view-parser": "^3.8.1",
     "can-view-scope": "^3.5.4",
     "can-view-target": "^3.1.0"
   },


### PR DESCRIPTION
can-view-parser: latest version fixes bad parsing when the close tag character `>` is in an attribute value
can-util: versions prior to 3.10.12 cause test failures due to can-util/js/dev/dev not using can-log/dev/dev for console warnings.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
