### PR TITLE
Fix false-positive key lookup warning when key is dotted

### DIFF
--- a/expressions/lookup.js
+++ b/expressions/lookup.js
@@ -25,7 +25,34 @@ Lookup.prototype.value = function(scope, readOptions){
 	//!steal-remove-start
 	if (typeof value.initialValue === 'undefined') {
 		var context = value.startingScope && value.startingScope._context;
-		var propDefined = typeof context === "object" && canReflect.hasKey(context, this.key);
+		var propDefined = false;
+
+		if(typeof context === "object") {
+			if(!value.reads) {
+				propDefined = canReflect.hasKey(context, this.key);
+			} else {
+				var reads = value.reads, i = 0, readsLength = reads.length;
+				var read;
+				do {
+					read = reads[i];
+					if(canReflect.hasKey(context, read.key)) {
+						propDefined = true;
+
+						// Get the next context and continue to see if the key is defined.
+						context = canReflect.getKeyValue(context, read.key);
+
+						if(context) {
+							propDefined = false;
+						} else {
+							break;
+						}
+					}
+					i++;
+				} while(i < readsLength);
+			}
+		}
+
+		//var propDefined = typeof context === "object" && canReflect.hasKey(context, this.key);
 
 		if (!propDefined) {
 			dev.warn('can-stache/expressions/lookup.js: Unable to find key "' + this.key + '".');

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6660,6 +6660,19 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(teardown(), 0, 'did not get warning');
 	});
 
+	testHelpers.dev.devOnlyTest("should not warn for keys dotted keys that exist", function () {
+		var VM = DefineMap.extend({
+			env: DefineMap.extend({
+				"NODE_ENV": "any"
+			})
+		});
+		var vm = new VM();
+		var teardown = testHelpers.dev.willWarn(/Unable to find key/);
+		stache('{{env.NODE_ENV}}')(vm);
+
+		QUnit.equal(teardown(), 0, "did not warning");
+	})
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6661,17 +6661,35 @@ function makeTest(name, doc, mutation) {
 	});
 
 	testHelpers.dev.devOnlyTest("should not warn for keys dotted keys that exist", function () {
-		var VM = DefineMap.extend({
-			env: DefineMap.extend({
-				"NODE_ENV": "any"
-			})
+		var ENV = DefineMap.extend({
+			NODE_ENV: "any"
 		});
+
+		var VM = DefineMap.extend({
+			env: "any"
+		});
+
+		// First without anything
 		var vm = new VM();
 		var teardown = testHelpers.dev.willWarn(/Unable to find key/);
 		stache('{{env.NODE_ENV}}')(vm);
 
 		QUnit.equal(teardown(), 0, "did not warning");
-	})
+
+		// Then with an env but no prop
+		vm = new VM({env: new DefineMap()})
+		teardown = testHelpers.dev.willWarn(/Unable to find key/);
+		stache('{{env.NODE_ENV}}')(vm);
+
+		QUnit.equal(teardown(), 1, "did warn");
+
+		// Then with everything
+		vm = new VM({env: new ENV()});
+		teardown = testHelpers.dev.willWarn(/Unable to find key/);
+		stache('{{env.NODE_ENV}}')(vm);
+
+		QUnit.equal(teardown(), 0, "did not warning");
+	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 


### PR DESCRIPTION
When given a key like `foo.bar`, first check if `foo` is defined on the
context, and then check if `bar` is defined on `foo`. Each step of the
way, we only care that `hasKey` is truthy, if the context doesn't exist
at any point, we don't warn, because the lookup will rerun once a value
is set. Fixes #462