### PR TITLE
Use can-dom-mutate/node to set attributes

### DIFF
--- a/src/text_section.js
+++ b/src/text_section.js
@@ -2,7 +2,7 @@ var live = require('can-view-live');
 
 var utils = require('./utils');
 
-var domMutate = require("can-dom-mutate");
+var domMutate = require("can-dom-mutate/node");
 
 var assign = require('can-assign');
 
@@ -72,7 +72,7 @@ assign(TextSectionBuilder.prototype,{
 					this.nodeValue = value;
 				}
 				else if(state.attr) {
-					domMutate.setAttribute(this, state.attr, value);
+					domMutate.setAttribute.call(this, state.attr, value);
 				}
 				else {
 					live.attrs(this, value);

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6728,6 +6728,14 @@ function makeTest(name, doc, mutation) {
 
 	});
 
+	QUnit.test("Can call helpers (helper expressions) within attributes", function(){
+		var vm = {
+			name: function() { return "matthew"; }
+		};
+		var frag = stache("<div id='{{name}}'></div>")(vm);
+		QUnit.equal(frag.firstChild.getAttribute("id"), "matthew", "able to set the attribute");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
This fixes a case where using helper expressions to set an attribute
would throw. Fixes #467

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
