### PR TITLE
Fixing magic tags within attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "can-symbol": "^1.0.0",
     "can-util": "^3.10.6",
     "can-view-callbacks": "^4.0.0",
-    "can-view-live": "^4.0.0",
+    "can-view-live": "^4.0.3",
     "can-view-nodelist": "^4.0.0",
     "can-view-parser": "^4.0.0",
     "can-view-scope": "^4.0.0",

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -222,11 +222,6 @@ var core = {
 			// Use the full mustache expression as the cache key.
 			fullExpression = mode+expressionString;
 
-		// convert a lookup like `{{value}}` to still be called as a helper if necessary.
-		if(!(exprData instanceof expression.Helper) && !(exprData instanceof expression.Call)) {
-			exprData = new expression.Helper(exprData,[],{});
-		}
-
 		// A branching renderer takes truthy and falsey renderer.
 		var branchRenderer = function branchRenderer(scope, truthyRenderer, falseyRenderer){
 			//!steal-remove-start

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6751,6 +6751,23 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(innerHTML(div), "peasant: Johnny", "{{#default()}}");
 	});
 
+	QUnit.test("Can use magic tags within attributes (#470)", function(){
+		var vm = new DefineMap({
+			name: ""
+		});
+		var frag = stache("<input value='{{name}}'>")(vm);
+		QUnit.equal(frag.firstChild.value, "", "initially empty");
+
+		vm.name = "matthew";
+		QUnit.equal(frag.firstChild.value, "matthew", "set to matthew");
+
+		frag.firstChild.value = "mark"
+		QUnit.equal(frag.firstChild.value, "mark", "set to mark");
+
+		vm.name = "paul";
+		QUnit.equal(frag.firstChild.value, "paul", "set to paul");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6768,6 +6768,17 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(frag.firstChild.value, "paul", "set to paul");
 	});
 
+	testHelpers.dev.devOnlyTest("Can use magic tags within attributes without warnings (#477)", function(){
+		var teardown = testHelpers.dev.willWarn(/Unable to find helper/);
+
+		var vm = new DefineMap({
+			name: ""
+		});
+		var frag = stache("<input value='{{name}}'>")(vm);
+
+		QUnit.equal(teardown(), 0, "no warning");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
closes https://github.com/canjs/can-stache/issues/470 and https://github.com/canjs/can-stache/issues/477.