### PR TITLE
Negative numbers should be parsed as literals

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -35,7 +35,7 @@ var Hash = function(){ }; // jshint ignore:line
 var keyRegExp = /[\w\.\\\-_@\/\&%]+/,
 	tokensRegExp = /('.*?'|".*?"|=|[\w\.\\\-_@\/*%\$]+|[\(\)]|,|\~|\[|\]\s*|\s*(?=\[))/g,
 	bracketSpaceRegExp = /\]\s+/,
-	literalRegExp = /^('.*?'|".*?"|[0-9]+\.?[0-9]*|true|false|null|undefined)$/;
+	literalRegExp = /^('.*?'|".*?"|-?[0-9]+\.?[0-9]*|true|false|null|undefined)$/;
 
 var isTokenKey = function(token){
 	return keyRegExp.test(token);

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -972,3 +972,15 @@ test('Call Expressions can return functions instead of Observations', function()
 	equal(canReflect.getValue(nonBindingVal.value), "mark", "got correct initial value");
 	ok(!canReflect.isObservableLike(nonBindingVal.value), "value is not observable when doNotWrapInObservation is true");
 });
+
+QUnit.test("negative literals ast", function(assert) {
+	var ast = expression.ast("adjust(-10)");
+
+	var expected = {
+		children: [{ type: "Literal", value: -10 }],
+		method: { key: "@adjust", type: "Lookup" },
+		type: "Call"
+	};
+
+	assert.deepEqual(ast, expected);
+});


### PR DESCRIPTION
Closes #458

```js
var stache = require('can-stache');
var SimpleMap = require('can-simple-map');
require('can-stache-bindings');

var view = stache(`
  <button on:click="adjust(10)">Up</button>
  <button on:click="adjust(-10)">Down</button>
`);

var scope = new SimpleMap({
  adjust: function(delta) {
    console.log(delta);
  }
});

document.body.appendChild(view(scope));
```

![kapture 2018-02-28 at 15 24 42](https://user-images.githubusercontent.com/724877/36816767-10d96ae0-1c9c-11e8-811e-516d1c53bf85.gif)
