### PR TITLE
Hash expressions used in each helper should not warn

### DIFF
--- a/expressions/call.js
+++ b/expressions/call.js
@@ -21,12 +21,14 @@ var Call = function(methodExpression, argExpressions){
 Call.prototype.args = function(scope, ignoreArgLookup) {
 	var hashExprs = {};
 	var args = [];
-	for(var i = 0, len = this.argExprs.length; i < len; i++) {
+	var gotIgnoreFunction = typeof ignoreArgLookup === "function";
+
+	for (var i = 0, len = this.argExprs.length; i < len; i++) {
 		var arg = this.argExprs[i];
 		if(arg.expr instanceof Hashes){
 			assign(hashExprs, arg.expr.hashExprs);
 		}
-		if (typeof ignoreArgLookup !== "function" || !ignoreArgLookup(arg)) {
+		if (!gotIgnoreFunction || !ignoreArgLookup(i)) {
 			var value = arg.value.apply(arg, arguments);
 			args.push({
 				// always do getValue unless compute is false

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -137,8 +137,8 @@ var eachHelper = function(items) {
 };
 eachHelper.isLiveBound = true;
 eachHelper.requiresOptionsArgument = true;
-eachHelper.ignoreArgLookup = function ignoreArgLookup(arg) {
-	return arg.expr instanceof Hashes;
+eachHelper.ignoreArgLookup = function ignoreArgLookup(index) {
+	return index === 1;
 };
 
 var indexHelper = function(offset, options) {

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -137,6 +137,9 @@ var eachHelper = function(items) {
 };
 eachHelper.isLiveBound = true;
 eachHelper.requiresOptionsArgument = true;
+eachHelper.ignoreArgLookup = function ignoreArgLookup(arg) {
+	return arg.expr instanceof Hashes;
+};
 
 var indexHelper = function(offset, options) {
 	if (!options) {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -3503,6 +3503,23 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(teardown(), 0, 'no warnings shown');
 	});
 
+	testHelpers.dev.devOnlyTest("Logging: hashes in #each helper should not trigger warning", function () {
+		var teardown = testHelpers.dev.willWarn(
+			/can-stache\/expressions\/lookup.js: Unable to find key/
+		);
+
+		var tpl = stache("{{#each(panels, panel=value)}} {{panel.label}} {{/each}}");
+		tpl({
+			panels: [
+				{ label: "foo" },
+				{ label: "bar" },
+				{ label: "baz" },
+			]
+		});
+
+		QUnit.equal(teardown(), 0, 'no warnings shown');
+	});
+
 	test("Calling .fn without arguments should forward scope by default (#658)", function(){
 		var tmpl = "{{#foo()}}<span>{{bar}}</span>{{/foo}}";
 		var frag = stache(tmpl)(new SimpleMap({


### PR DESCRIPTION
Closes #461 

The jsbin attached to the issue https://jsbin.com/nutotejuno/edit?html,js,console shows more warnings due to a mistake instantiating the scope map:

```js
var appViewModel = new can.DefineMap({
  // this should be `panels: panels` 
  panels: {
    // the DefineMap should be extended for this to work, 
    // that's why can-stache can't find panel.label when rendering the template.
    default: panels 
  }
});
```

Once the issue mentioned above is fixed ^ the only warning shows in about `value` which is fixed by this PR.

![screen shot 2018-03-01 at 1 34 50 pm](https://user-images.githubusercontent.com/724877/36870225-9deefc82-1d5b-11e8-9bfd-2a512a70c0ed.png)

