### PR TITLE
[3.x] fix inline partials not being available when using helpers scope.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "donejs"
   ],
   "dependencies": {
-    "can-attribute-encoder": "^0.3.0",
+    "can-attribute-encoder": "^0.3.4",
     "can-compute": "^3.3.1",
     "can-globals": "<2.0.0",
     "can-log": "^1.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "^3.3.1",
-    "can-reflect": "^1.2.1",
+    "can-reflect": "^1.13.3",
     "can-route": "^3.3.3",
     "can-stache-key": "^0.1.2",
     "can-symbol": "^1.0.0",
@@ -60,10 +60,10 @@
     "can-vdom": "^3.1.0",
     "detect-cyclic-packages": "^1.1.0",
     "jshint": "^2.9.4",
-    "steal": "^1.0.5",
+    "steal": "^1.9.1",
     "steal-benchmark": "^0.0.1",
     "steal-qunit": "^1.0.0",
-    "steal-tools": "^1.0.1",
+    "steal-tools": "^1.11.5",
     "testee": "^0.7.0"
   }
 }

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -70,7 +70,7 @@ var core = {
 				scope: scope,
 				nodeList: nodeList,
 				exprData: exprData,
-				helpersScope: helperOptions
+				helpers: helperOptions
 			};
 			utils.convertToScopes(helperOptionArg, scope,helperOptions, nodeList, truthyRenderer, falseyRenderer, stringOnly);
 
@@ -194,7 +194,11 @@ var core = {
 				}
 				// Look up partials in options first.
 				var partial = options.peek("partials." + localPartialName);
-				partial = partial || ( options.inlinePartials && options.inlinePartials[ localPartialName ] );
+				var parent = options;
+				while(!partial && parent) {
+					partial = parent.inlinePartials && parent.inlinePartials[ localPartialName ];
+					parent = parent._parent;
+				}
 				var renderer;
 				if (partial) {
 					renderer = function() {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7195,6 +7195,21 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(scope.get("scope.lineNumber"), 1);
 	});
 
+	test("inline partials available in switch", function() {
+		var renderer = stache(
+			"{{<aPartial}}foo{{/aPartial}}" +
+			"<span>{{#switch(0)}}" +
+				"{{#case(0)}}" +
+				"{{>aPartial}} should be foo" +
+				"{{/case}}" +
+			"{{/switch}}</span>"
+		);
+
+		var view = renderer(new DefineMap());
+
+		equal(view.firstChild.innerHTML, "foo should be foo", "inline partial renders");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
For stache core helpers, this primarily affected the `{{#switch}}` helper, since it uses the `helpers` scope to add `{{#case}}` and `{{#default}}` to the scope without affecting the current content.

An example of how to make this fail previously was:

```
 {{<aPartial}}foo{{/aPartial}}
  <span>{{#switch(0)}}
   {{#case(0)}}
     {{>aPartial}} should be foo
   {{/case}}
  {{/switch}}</span>
```

This PR adds a simple parent walk when looking for `inlinePartials`, which is sufficient to catch cases where `inlinePartials` was not copied parent-to-child.

Because of different lookup mechanisms for partials in 4.x, this bug does not affect 4.x and this patch does not need to be ported.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
