### PR TITLE
Fixes #494. Adds filename and constuctor name (if available) to warning

### DIFF
--- a/expressions/helper.js
+++ b/expressions/helper.js
@@ -64,7 +64,11 @@ Helper.prototype.value = function(scope, helperOptions){
 	}
 	//!steal-remove-start
 	else {
-		dev.warn('can-stache/expressions/helper.js: Unable to find helper "' + methodKey + '".');
+		var message = 'Unable to find helper "' + methodKey + '"';
+		if (scope.templateContext.filename) {
+			message = '"' + scope.templateContext.filename + '": ' + message;
+		}
+		dev.warn(message + '.');
 	}
 	//!steal-remove-end
 

--- a/expressions/lookup.js
+++ b/expressions/lookup.js
@@ -55,7 +55,15 @@ Lookup.prototype.value = function(scope, readOptions){
 		//var propDefined = typeof context === "object" && canReflect.hasKey(context, this.key);
 
 		if (!propDefined) {
-			dev.warn('can-stache/expressions/lookup.js: Unable to find key "' + this.key + '".');
+			var message = 'Unable to find key "' + this.key + '"';
+			if (scope.templateContext.filename) {
+				message = '"' + scope.templateContext.filename + '": ' + message;
+			}
+			var contextName = context && context.constructor.name;
+			if (contextName && contextName !== 'DefineMap' && contextName !== 'Object') {
+				message = message + ' in ' + '"' + contextName + '"';
+			}
+			dev.warn(message + '.');
 		}
 	}
 	//!steal-remove-end

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -3446,7 +3446,7 @@ function makeTest(name, doc, mutation) {
 	});
 
 	testHelpers.dev.devOnlyTest("Logging: Helper not found in stache template(#726)", function () {
-		var teardown = testHelpers.dev.willWarn('can-stache/expressions/helper.js: Unable to find helper "helpme".');
+		var teardown = testHelpers.dev.willWarn('Unable to find helper "helpme".');
 
 		stache('<li>{{helpme name}}</li>')({
 			name: 'Hulk Hogan'
@@ -3455,9 +3455,8 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(teardown(), 1, 'got expected warning');
 	});
 
-	testHelpers.dev.devOnlyTest("Logging: Variable not found in stache template (#720)", function () {
-		var teardown = testHelpers.dev.willWarn('can-stache/expressions/lookup.js: Unable to find key "user.name".');
-
+	testHelpers.dev.devOnlyTest("Logging: Variable not found in stache template (#720, #494)", function () {
+		var teardown = testHelpers.dev.willWarn('Unable to find key "user.name".');
 		stache('<li>{{user.name}}</li>')({
 			user: {}
 		});
@@ -3466,7 +3465,7 @@ function makeTest(name, doc, mutation) {
 	});
 
 	testHelpers.dev.devOnlyTest("Logging: Variable not found in stache template should not happen for falsey values", function () {
-		var teardown = testHelpers.dev.willWarn(/can-stache\/expressions\/lookup.js: Unable to find key/);
+		var teardown = testHelpers.dev.willWarn(/Unable to find key/);
 
 		stache('{{bool}} {{emptyString}}')({
 			bool: false,
@@ -3477,9 +3476,7 @@ function makeTest(name, doc, mutation) {
 	});
 
 	testHelpers.dev.devOnlyTest("Logging: hashes in #each helper should not trigger warning", function () {
-		var teardown = testHelpers.dev.willWarn(
-			/can-stache\/expressions\/lookup.js: Unable to find key/
-		);
+		var teardown = testHelpers.dev.willWarn(/Unable to find key/);
 
 		var tpl = stache("{{#each(panels, panel=value)}} {{panel.label}} {{/each}}");
 		tpl({


### PR DESCRIPTION
Fixes https://github.com/canjs/can-stache/issues/494

I need a hand with properly test this refactor.  And I am not entirely positive if I covered all cases for `context.constructor.name`, so help would be appreciated there as well.

Also, I wasn't sure if it was possible to reference the `context.constructor.name` for the missing helper functionality.

<img width="746" alt="screen shot 2018-03-16 at 13 06 09" src="https://user-images.githubusercontent.com/212726/37537261-5aefc1d6-2923-11e8-8dec-30fb4f911331.png">

<img width="856" alt="screen shot 2018-03-16 at 13 06 19" src="https://user-images.githubusercontent.com/212726/37537264-5e72cc72-2923-11e8-88b3-9d06f3c0ced9.png">

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
