### PR TITLE
Add support for can.viewInsert

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "can-symbol": "^1.0.0",
     "can-util": "^3.10.6",
     "can-view-callbacks": "^4.0.0",
-    "can-view-live": "^4.0.3",
+    "can-view-live": "^4.1.0-pre.1",
     "can-view-nodelist": "^4.0.0",
     "can-view-parser": "^4.0.0",
     "can-view-scope": "^4.0.3",

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -31,6 +31,7 @@ var getDocument = require("can-globals/document/document");
 var mustacheLineBreakRegExp = /(?:(^|\r?\n)(\s*)(\{\{([\s\S]*)\}\}\}?)([^\S\n\r]*)($|\r?\n))|(\{\{([\s\S]*)\}\}\}?)/g,
 	mustacheWhitespaceRegExp = /(\s*)(\{\{\{?)(-?)([\s\S]*?)(-?)(\}\}\}?)(\s*)/g,
 	k = function(){};
+var viewInsertSymbol = canSymbol.for("can.viewInsert");
 
 
 var core = {
@@ -360,7 +361,9 @@ var core = {
 					live.text(this, observable, this.parentNode, nodeList);
 				}
 				else {
-					live.html(this, observable, this.parentNode, nodeList);
+					live.html(this, observable, this.parentNode, {
+						nodeList: nodeList
+					});
 				}
 			}
 			// If the computeValue has no observable dependencies, just set the value on the element.
@@ -376,7 +379,13 @@ var core = {
 					this.nodeValue = value;
 				}
 				else if( value != null ){
-					nodeLists.replace([this], frag(value, this.ownerDocument));
+					if (typeof value[viewInsertSymbol] === "function") {
+						nodeLists.replace([this], value[viewInsertSymbol]({
+							nodeList: nodeList
+						}));
+					} else {
+						nodeLists.replace([this], frag(value, this.ownerDocument));
+					}
 				}
 			}
 			// Unbind the compute.

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6903,6 +6903,20 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal( innerHTML(frag.firstChild), "bar", "updated to bar");
 	});
 
+	QUnit.test("render objects with can.viewInsert symbol (#502)", function(assert) {
+		var viewInsertSymbol = canSymbol.for("can.viewInsert");
+		var objectWithSymbol = {};
+		objectWithSymbol[viewInsertSymbol] = function() {
+			return doc.createTextNode("Hello world");
+		};
+		var fragment = stache("<p>{{{objectWithSymbol}}}</p>")({
+			objectWithSymbol: objectWithSymbol
+		});
+
+		// Basics look correct
+		assert.equal(innerHTML(fragment.firstChild), "Hello world", "fragment has correct text content");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
This makes the following work:

```js
stache("{{{key}}}")({
	key: {
		[canSymbol.for("can.viewInsert")]: function() {
			return // a dom node
		}
	}
});
// Renders whatever is returned by the can.viewInsert function
```

This works by checking whether the can.viewInsert symbol is defined on the value being rendered; if it is, then the function is called and the return value is rendered.

These changes are part of https://github.com/canjs/can-stache/issues/502