### PR TITLE
Treats functions as truthy

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -59,6 +59,9 @@ var eachHelper = function(items) {
 		canReflect.isObservableLike(resolved) && canReflect.isListLike(resolved) ||
 			( utils.isArrayLike(resolved) && canReflect.isValueLike(items))
 	) && !options.stringOnly) {
+		// Tells that a helper has been called, this function should be returned through
+		// checking its value.
+		options.metadata.rendered = true;
 		return function(el){
 			// make a child nodeList inside the can.view.live.html nodeList
 			// so that if the html is re

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -95,6 +95,7 @@ var core = {
 		if(!mode || helperOptions.metadata.rendered) {
 			return value;
 		} else if( mode === "#" || mode === "^" ) {
+
 			return function(){
 				// Get the value
 				var finalValue = canReflect.getValue(value);
@@ -104,11 +105,6 @@ var core = {
 				// as what should be put in the DOM.
 				if(helperOptions.metadata.rendered) {
 					result = finalValue;
-				}
-				// OTHERWISE; we will call `.fn` and `.inverse` ourselves based on what
-				// the value looks like.
-				else if(typeof finalValue === "function") {
-					return finalValue;
 				}
 				// If it's an array, render.
 				else if ( typeof finalValue !== "string" && utils.isArrayLike(finalValue) ) {

--- a/test/section-test.js
+++ b/test/section-test.js
@@ -1,20 +1,17 @@
 var QUnit = require("steal-qunit");
 var stache = require("can-stache");
-var DefineMap = require("can-define/map/map");
-var DefineList = require("can-define/list/list");
-var define = require("can-define");
 
 QUnit.module("can-stache - {{#section}} tests");
 
-QUnit.test("function values treated the same", function(assert){
+QUnit.test("function values treated the same within and between tags (#510)", function(assert){
     var obj = {func: function(){ return "Hello"; }};
 
-    var inHTML = stache("<div>{{#func}}FN{{/func}}</div>");
+    var inHTML = stache("<div>{{#func}}fn{{/func}}</div>");
     var res = inHTML(obj);
-    assert.equal(res.firstChild.innerHTML, "FN", "works in HTML");
+    assert.equal(res.firstChild.innerHTML, "fn", "works in HTML");
 
-    var inTag = stache("<div {{#func}}FN{{/func}}></div>");
+    var inTag = stache("<div {{#func}}fn{{/func}}></div>");
     var frag = inTag(obj);
-    assert.ok(frag.firstChild.hasAttribute("FN"));
-    assert.notOk(frag.firstChild.hasAttribute("FN"));
+    assert.ok(frag.firstChild.hasAttribute("fn"),"within tag ok");
+    assert.notOk(frag.firstChild.hasAttribute("Hello"),"within tag ok");
 });

--- a/test/section-test.js
+++ b/test/section-test.js
@@ -1,0 +1,20 @@
+var QUnit = require("steal-qunit");
+var stache = require("can-stache");
+var DefineMap = require("can-define/map/map");
+var DefineList = require("can-define/list/list");
+var define = require("can-define");
+
+QUnit.module("can-stache - {{#section}} tests");
+
+QUnit.test("function values treated the same", function(assert){
+    var obj = {func: function(){ return "Hello"; }};
+
+    var inHTML = stache("<div>{{#func}}FN{{/func}}</div>");
+    var res = inHTML(obj);
+    assert.equal(res.firstChild.innerHTML, "FN", "works in HTML");
+
+    var inTag = stache("<div {{#func}}FN{{/func}}></div>");
+    var frag = inTag(obj);
+    assert.ok(frag.firstChild.hasAttribute("FN"));
+    assert.notOk(frag.firstChild.hasAttribute("FN"));
+});

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -2,6 +2,7 @@
 require('./expression-test');
 require('../helpers/-debugger-test');
 require('./nodelist-test');
+require('./section-test');
 var stache = require('can-stache');
 var core = require('can-stache/src/mustache_core');
 var clone = require('steal-clone');


### PR DESCRIPTION
Fixes #510 

Make #each set the `metadata.rendered` to true.  All other functions are treated as truthy.