### PR TITLE
Show filename/lineNumber from where scope key was looked up

### DIFF
--- a/src/expression-helpers.js
+++ b/src/expression-helpers.js
@@ -49,8 +49,8 @@ function displayScopeWalkingWarning(key, computeData) {
 
 		// if scope was walked and value isn't an alias, display dev warning
 		if (scopeWasWalked && !readFromNonContext && !readFromSpecialContext) {
-			var filename = computeData.scope.peek('scope.filename');
-			var lineNumber = computeData.scope.peek('scope.lineNumber');
+			var filename = computeData.startingScope.peek('scope.filename');
+			var lineNumber = computeData.startingScope.peek('scope.lineNumber');
 			var displayKey = key.replace(/^@/g, "").replace(/@/g, ".");
 			var explicitKeys = getExplicitKeys(displayKey, computeData.startingScope, computeData.scope);
 


### PR DESCRIPTION
Instead of the filename/lineNumber from where it was found, which is
sometimes a different template entirely with a meaningless line number.