### PR TITLE
not giving same key that was used in missing key warning for nested properties

### DIFF
--- a/expressions/lookup.js
+++ b/expressions/lookup.js
@@ -35,18 +35,20 @@ Lookup.prototype.value = function(scope, readOptions){
 		var pathsForKey = scope.getPathsForKey(firstKey);
 		var paths = Object.keys( pathsForKey );
 
+		var includeSuggestions = paths.length && !paths.includes(firstKey);
+
 		var warning = [
 			(filename ? filename + ':' : '') +
 				(lineNumber ? lineNumber + ': ' : '') +
 				'Unable to find key "' + key + '".' +
 				(
-					paths.length ?
+					includeSuggestions ?
 						" Did you mean" + (paths.length > 1 ? " one of these" : "") + "?\n" :
 						"\n"
 				)
 		];
 
-		if (paths.length) {
+		if (includeSuggestions) {
 			paths.forEach(function(path) {
 				warning.push('\t"' + path + '" which will read from');
 				warning.push(pathsForKey[path]);

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6809,6 +6809,24 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(teardown(), 0, "did not warn");
 	});
 
+	testHelpers.dev.devOnlyTest("Warnings for nested properties should not suggest using the same key (#536)", function () {
+		var Abc = DefineMap.extend({});
+		var VM = DefineMap.extend({
+			abc: {
+				Default: Abc
+			}
+		});
+
+		var vm = new VM();
+		var scope = new Scope(vm, null, { viewModel: true });
+		var warningTeardown = testHelpers.dev.willWarn(/Unable to find key/);
+		var suggestionTeardown = testHelpers.dev.willWarn(/will read from/);
+		stache('{{abc.def}}')(scope);
+
+		QUnit.equal(warningTeardown(), 1, "gave warning");
+		QUnit.equal(suggestionTeardown(), 0, "did not give suggestions");
+	});
+
 	testHelpers.dev.devOnlyTest("Variable not found warning should suggest correct keys", function () {
 		var origGetPaths = Scope.prototype.getPathsForKey;
 		Scope.prototype.getPathsForKey = function(key) {


### PR DESCRIPTION
closes https://github.com/canjs/can-stache/issues/536.