### PR TITLE
Add docs for rendering component instances in templates

### DIFF
--- a/docs/magicTagTypes.md
+++ b/docs/magicTagTypes.md
@@ -51,6 +51,35 @@ Inserts the unescaped value of `expression` into the result.
 <div><b>Justin</b></div>
 ```
 
+This also works for rendering [can-component] instances:
+
+```js
+import Component from "can-component";
+import stache from "can-stache";
+
+const MyGreeting = Component.extend({
+  tag: "my-greeting",
+  view: "<p>Hello {{subject}}</p>",
+  ViewModel: {
+    subject: "string"
+  }
+});
+
+const myGreetingInstance = new MyGreeting({
+  viewModel: {
+    subject: "friend"
+  }
+});
+
+const template = stache("<div>{{{componentInstance}}}</div>");
+
+const fragment = template({
+  componentInstance: myGreetingInstance
+});
+
+fragment; //-> <div><p>Hello friend</p></div>
+```
+
 #### [can-stache.tags.partial]
 
 Renders another template with the same context as the current context.

--- a/docs/magicTagTypes.md
+++ b/docs/magicTagTypes.md
@@ -77,7 +77,7 @@ const fragment = template({
   componentInstance: myGreetingInstance
 });
 
-fragment; //-> <div><p>Hello friend</p></div>
+fragment; //-> <div><my-greeting><p>Hello friend</p></my-greeting></div>
 ```
 
 #### [can-stache.tags.partial]

--- a/docs/tags/unescaped.md
+++ b/docs/tags/unescaped.md
@@ -44,5 +44,5 @@ const fragment = template({
   componentInstance: myGreetingInstance
 });
 
-fragment; //-> <div><p>Hello friend</p></div>
+fragment; //-> <div><my-greeting><p>Hello friend</p></my-greeting></div>
 ```

--- a/docs/tags/unescaped.md
+++ b/docs/tags/unescaped.md
@@ -15,3 +15,34 @@ escape the result.
 ```
 
 @param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/helper} EXPRESSION An expression whose unescaped result is inserted into the page.
+
+@body
+
+This can also be used to render [can-component] instances:
+
+```js
+import Component from "can-component";
+import stache from "can-stache";
+
+const MyGreeting = Component.extend({
+  tag: "my-greeting",
+  view: "<p>Hello {{subject}}</p>",
+  ViewModel: {
+    subject: "string"
+  }
+});
+
+const myGreetingInstance = new MyGreeting({
+  viewModel: {
+    subject: "friend"
+  }
+});
+
+const template = stache("<div>{{{componentInstance}}}</div>");
+
+const fragment = template({
+  componentInstance: myGreetingInstance
+});
+
+fragment; //-> <div><p>Hello friend</p></div>
+```


### PR DESCRIPTION
Added a note in the magic tag types docs:
<img width="659" alt="screen shot 2018-06-18 at 11 39 31 am" src="https://user-images.githubusercontent.com/10070176/41555792-9e717bb6-72ed-11e8-81ab-8e8b57901662.png">

Also added the same example to the `{{{expression}}}` docs:
<img width="849" alt="screen shot 2018-06-18 at 11 46 38 am" src="https://user-images.githubusercontent.com/10070176/41555816-b054a8e4-72ed-11e8-8482-13e8f93d3102.png">

Part of https://github.com/canjs/can-stache/issues/502