### PR TITLE
Preserve the correct filename for reporting even after loading a partial with a different filename

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -87,7 +87,7 @@ function stache (filename, template) {
 
 			if(mode === ">") {
 				// Partials use liveBindingPartialRenderers
-				section.add(mustacheCore.makeLiveBindingPartialRenderer(stache, copyState({ lineNo: lineNo })));
+				section.add(mustacheCore.makeLiveBindingPartialRenderer(stache, copyState({ filename: section.filename, lineNo: lineNo })));
 
 			} else if(mode === "/") {
 
@@ -133,11 +133,11 @@ function stache (filename, template) {
 				if(mode === "{" || mode === "&") {
 
 					// Adds a renderer function that just reads a value or calls a helper.
-					section.add(makeRenderer(null,stache, copyState({ lineNo: lineNo })));
+					section.add(makeRenderer(null,stache, copyState({ filename: section.filename, lineNo: lineNo })));
 
 				} else if(mode === "#" || mode === "^" || mode === "<") {
 					// Adds a renderer function and starts a section.
-					var renderer = makeRenderer(mode, stache, copyState({ lineNo: lineNo }));
+					var renderer = makeRenderer(mode, stache, copyState({ filename: section.filename, lineNo: lineNo }));
 					section.startSection(renderer);
 					section.last().startedWith = mode;
 
@@ -157,7 +157,7 @@ function stache (filename, template) {
 					}
 				} else {
 					// Adds a renderer function that only updates text.
-					section.add(makeRenderer(null, stache, copyState({text: true, lineNo: lineNo })));
+					section.add(makeRenderer(null, stache, copyState({text: true, filename: section.filename, lineNo: lineNo })));
 				}
 
 			}
@@ -410,7 +410,7 @@ function stache (filename, template) {
 					state.node.attributes = [];
 				}
 				if(!mode) {
-					state.node.attributes.push(mustacheCore.makeLiveBindingBranchRenderer(null, expression, copyState({ lineNo: lineNo })));
+					state.node.attributes.push(mustacheCore.makeLiveBindingBranchRenderer(null, expression, copyState({ filename: section.filename, lineNo: lineNo })));
 				} else if( mode === "#" || mode === "^" ) {
 					if(!state.node.section) {
 						state.node.section = new TextSectionBuilder();

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -155,6 +155,7 @@ var core = {
 
 		return function(scope, parentSectionNodeList){
 			//!steal-remove-start
+			scope.set('scope.filename', state.filename);
 			scope.set('scope.lineNumber', state.lineNo);
 			//!steal-remove-end
 			var nodeList = [this];
@@ -205,7 +206,6 @@ var core = {
 							var domRenderer = core.getTemplateById(localPartialName);
 							return domRenderer ? domRenderer(scope, {}, nodeList) : getDocument().createDocumentFragment();
 						}
-
 					};
 				}
 				var res = ObservationRecorder.ignore(renderer)();
@@ -235,6 +235,7 @@ var core = {
 		// A branching renderer takes truthy and falsey renderer.
 		var branchRenderer = function branchRenderer(scope, truthyRenderer, falseyRenderer){
 			//!steal-remove-start
+			scope.set('scope.filename', state.filename);
 			scope.set('scope.lineNumber', state.lineNo);
 			//!steal-remove-end
 			// Check the scope's cache if the evaluator already exists for performance.
@@ -289,6 +290,7 @@ var core = {
 			// If this is within a tag, make sure we only get string values.
 			var stringOnly = state.tag;
 			//!steal-remove-start
+			scope.set('scope.filename', state.filename);
 			scope.set('scope.lineNumber', state.lineNo);
 			//!steal-remove-end
 			var nodeList = [this];

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6386,6 +6386,21 @@ function makeTest(name, doc, mutation) {
 		equal(frag.firstChild.nodeValue, 'some-file');
 	});
 
+	testHelpers.dev.devOnlyTest("scope has correct filename after calling a partial", function(){
+		var innerTemplate = stache('some-partial', '<span>{{scope.filename}}</span>');
+		var outerTemplate = stache('some-file', '{{#if foo}}{{scope.filename}}{{/if}}{{>somePartial}}');
+		var vm = new DefineMap()
+		var frag = outerTemplate(vm, {
+			partials: {
+				somePartial: innerTemplate
+			}
+		});
+		vm.set('foo', 'bar');
+
+		equal(frag.firstChild.nodeValue, 'some-file');
+		equal(frag.firstChild.nextSibling.firstChild.nodeValue, 'some-partial');
+	});
+
 	QUnit.test("using scope.index works when using #each with arrays", function() {
 		var data = {
 			itemsArray: [ "zero", "one", "two" ]


### PR DESCRIPTION
for #544

Make sure, when setting the line number for reporting logs or warnings, that the filename is also set, since a partial from a different file may previously have been called and updated the scope state.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
