### PR TITLE
fix dev code for webpack compatibility

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -99,8 +99,9 @@ function stache (filename, template) {
 					section.endSection();
 				}
 
-				if(section instanceof HTMLSectionBuilder) {
-					//!steal-remove-start
+				// to avoid "Blocks are nested too deeply" when linting
+				//!steal-remove-start
+				if(section instanceof HTMLSectionBuilder && process.env.NODE_ENV !== 'production') {
 					var last = state.sectionElementStack[state.sectionElementStack.length - 1];
 					if (last.tag && last.type === "section" && stache !== "" && stache !== last.tag) {
 						if (filename) {
@@ -110,8 +111,10 @@ function stache (filename, template) {
 							dev.warn(lineNo + ": unexpected closing tag {{/" + stache + "}} expected {{/" + last.tag + "}}");
 						}
 					}
-					//!steal-remove-end
+				}
+				//!steal-remove-end
 
+				if(section instanceof HTMLSectionBuilder) {
 					state.sectionElementStack.pop();
 				}
 			} else if(mode === "else") {
@@ -138,22 +141,23 @@ function stache (filename, template) {
 				} else if(mode === "#" || mode === "^" || mode === "<") {
 					// Adds a renderer function and starts a section.
 					var renderer = makeRenderer(mode, stache, copyState({ filename: section.filename, lineNo: lineNo }));
+					var sectionItem = {
+						type: "section"
+					};
 					section.startSection(renderer);
 					section.last().startedWith = mode;
 
 					// If we are a directly nested section, count how many we are within
 					if(section instanceof HTMLSectionBuilder) {
 						//!steal-remove-start
-						var tag = typeof renderer.exprData.closingTag === 'function' ?
-							renderer.exprData.closingTag() : '';
+						if (process.env.NODE_ENV !== 'production') {
+							var tag = typeof renderer.exprData.closingTag === 'function' ?
+								renderer.exprData.closingTag() : '';
+							sectionItem.tag = tag;
+						}
 						//!steal-remove-end
-
-						state.sectionElementStack.push({
-							type: "section",
-							//!steal-remove-start
-							tag: tag
-							//!steal-remove-end
-						});
+						
+						state.sectionElementStack.push(sectionItem);
 					}
 				} else {
 					// Adds a renderer function that only updates text.
@@ -214,7 +218,9 @@ function stache (filename, template) {
 					// Call directlyNested now as it's stateful.
 					addAttributesCallback(state.node, function(scope, parentNodeList){
 						//!steal-remove-start
-						scope.set('scope.lineNumber', lineNo);
+						if (process.env.NODE_ENV !== 'production') {
+							scope.set('scope.lineNumber', lineNo);
+						}
 						//!steal-remove-end
 						viewCallbacks.tagHandler(this,tagName, {
 							scope: scope,
@@ -281,7 +287,9 @@ function stache (filename, template) {
 					var current = state.sectionElementStack[state.sectionElementStack.length - 1];
 					addAttributesCallback(oldNode, function(scope, parentNodeList){
 						//!steal-remove-start
-						scope.set('scope.lineNumber', lineNo);
+						if (process.env.NODE_ENV !== 'production') {
+							scope.set('scope.lineNumber', lineNo);
+						}
 						//!steal-remove-end
 						viewCallbacks.tagHandler(this,tagName, {
 							scope: scope,
@@ -321,10 +329,12 @@ function stache (filename, template) {
 				var attrCallback = viewCallbacks.attr(attrName);
 
 				//!steal-remove-start
-				var decodedAttrName = attributeEncoder.decode(attrName);
-				var weirdAttribute = !!wrappedAttrPattern.test(decodedAttrName) || !!colonWrappedAttrPattern.test(decodedAttrName);
-				if (weirdAttribute && !attrCallback) {
-					dev.warn("unknown attribute binding " + decodedAttrName + ". Is can-stache-bindings imported?");
+				if (process.env.NODE_ENV !== 'production') {
+					var decodedAttrName = attributeEncoder.decode(attrName);
+					var weirdAttribute = !!wrappedAttrPattern.test(decodedAttrName) || !!colonWrappedAttrPattern.test(decodedAttrName);
+					if (weirdAttribute && !attrCallback) {
+						dev.warn("unknown attribute binding " + decodedAttrName + ". Is can-stache-bindings imported?");
+					}
 				}
 				//!steal-remove-end
 
@@ -334,7 +344,9 @@ function stache (filename, template) {
 					}
 					state.node.attributes.push(function(scope, nodeList){
 						//!steal-remove-start
-						scope.set('scope.lineNumber', lineNo);
+						if (process.env.NODE_ENV !== 'production') {
+							scope.set('scope.lineNumber', lineNo);
+						}
 						//!steal-remove-end
 						attrCallback(this,{
 							attributeName: attrName,
@@ -444,7 +456,9 @@ function stache (filename, template) {
 		// allow the current renderer to be called with {{>scope.view}}
 		canReflect.setKeyValue(templateContext, 'view', scopifiedRenderer);
 		//!steal-remove-start
-		canReflect.setKeyValue(templateContext, 'filename', section.filename);
+		if (process.env.NODE_ENV !== 'production') {
+			canReflect.setKeyValue(templateContext, 'filename', section.filename);
+		}
 		//!steal-remove-end
 
 		return renderer.apply( this, arguments );

--- a/can-stache.js
+++ b/can-stache.js
@@ -83,6 +83,7 @@ function stache (filename, template) {
 		// given section and modify the section to use that renderer.
 		// For example, if an HTMLSection is passed with mode `#` it knows to
 		// create a liveBindingBranchRenderer and pass that to section.add.
+		// jshint maxdepth:5
 		makeRendererAndUpdateSection = function(section, mode, stache, lineNo){
 
 			if(mode === ">") {

--- a/can-stache.js
+++ b/can-stache.js
@@ -101,14 +101,16 @@ function stache (filename, template) {
 
 				// to avoid "Blocks are nested too deeply" when linting
 				//!steal-remove-start
-				if(section instanceof HTMLSectionBuilder && process.env.NODE_ENV !== 'production') {
-					var last = state.sectionElementStack[state.sectionElementStack.length - 1];
-					if (last.tag && last.type === "section" && stache !== "" && stache !== last.tag) {
-						if (filename) {
-							dev.warn(filename + ":" + lineNo + ": unexpected closing tag {{/" + stache + "}} expected {{/" + last.tag + "}}");
-						}
-						else {
-							dev.warn(lineNo + ": unexpected closing tag {{/" + stache + "}} expected {{/" + last.tag + "}}");
+				if (process.env.NODE_ENV !== 'production') {
+					if(section instanceof HTMLSectionBuilder) {
+						var last = state.sectionElementStack[state.sectionElementStack.length - 1];
+						if (last.tag && last.type === "section" && stache !== "" && stache !== last.tag) {
+							if (filename) {
+								dev.warn(filename + ":" + lineNo + ": unexpected closing tag {{/" + stache + "}} expected {{/" + last.tag + "}}");
+							}
+							else {
+								dev.warn(lineNo + ": unexpected closing tag {{/" + stache + "}} expected {{/" + last.tag + "}}");
+							}
 						}
 					}
 				}

--- a/expressions/arg.js
+++ b/expressions/arg.js
@@ -10,9 +10,11 @@ Arg.prototype.value = function(){
 	return this.expr.value.apply(this.expr, arguments);
 };
 //!steal-remove-start
-Arg.prototype.sourceText = function(){
-	return (this.modifiers.compute ? "~" : "")+ this.expr.sourceText();
-};
+if (process.env.NODE_ENV !== 'production') {
+	Arg.prototype.sourceText = function(){
+		return (this.modifiers.compute ? "~" : "")+ this.expr.sourceText();
+	};
+}
 //!steal-remove-end
 
 module.exports = Arg;

--- a/expressions/bracket.js
+++ b/expressions/bracket.js
@@ -1,5 +1,7 @@
 //!steal-remove-start
-var canSymbol = require('can-symbol');
+if (process.env.NODE_ENV !== 'production') {
+	var canSymbol = require('can-symbol');
+}
 //!steal-remove-end
 var expressionHelpers = require("../src/expression-helpers");
 
@@ -9,7 +11,9 @@ var Bracket = function (key, root, originalKey) {
 	this.root = root;
 	this.key = key;
 	//!steal-remove-start
-	this[canSymbol.for("can-stache.originalKey")] = originalKey;
+	if (process.env.NODE_ENV !== 'production') {
+		this[canSymbol.for("can-stache.originalKey")] = originalKey;
+	}
 	//!steal-remove-end
 };
 Bracket.prototype.value = function (scope, helpers) {
@@ -17,18 +21,22 @@ Bracket.prototype.value = function (scope, helpers) {
 	return expressionHelpers.getObservableValue_fromDynamicKey_fromObservable(this.key.value(scope, helpers), root, scope, helpers, {});
 };
 //!steal-remove-start
-Bracket.prototype.sourceText = function(){
-	if(this.rootExpr) {
-		return this.rootExpr.sourceText()+"["+this.key+"]";
-	} else {
-		return "["+this.key+"]";
-	}
-};
+if (process.env.NODE_ENV !== 'production') {
+	Bracket.prototype.sourceText = function(){
+		if(this.rootExpr) {
+			return this.rootExpr.sourceText()+"["+this.key+"]";
+		} else {
+			return "["+this.key+"]";
+		}
+	};
+}
 //!steal-remove-end
 
 Bracket.prototype.closingTag = function() {
 	//!steal-remove-start
-	return this[canSymbol.for('can-stache.originalKey')] || '';
+	if (process.env.NODE_ENV !== 'production') {
+		return this[canSymbol.for('can-stache.originalKey')] || '';
+	}
 	//!steal-remove-end
 };
 

--- a/expressions/call.js
+++ b/expressions/call.js
@@ -84,9 +84,11 @@ Call.prototype.value = function(scope, helperOptions){
 		}
 	};
 	//!steal-remove-start
-	Object.defineProperty(computeFn, "name", {
-		value: "{{" + this.sourceText() + "}}"
-	});
+	if (process.env.NODE_ENV !== 'production') {
+		Object.defineProperty(computeFn, "name", {
+			value: "{{" + this.sourceText() + "}}"
+		});
+	}
 	//!steal-remove-end
 
 	if (helperOptions && helperOptions.doNotWrapInObservation) {
@@ -98,17 +100,21 @@ Call.prototype.value = function(scope, helperOptions){
 	}
 };
 //!steal-remove-start
-Call.prototype.sourceText = function(){
-	var args = this.argExprs.map(function(arg){
-		return arg.sourceText();
-	});
-	return this.methodExpr.sourceText()+"("+args.join(",")+")";
-};
+if (process.env.NODE_ENV !== 'production') {
+	Call.prototype.sourceText = function(){
+		var args = this.argExprs.map(function(arg){
+			return arg.sourceText();
+		});
+		return this.methodExpr.sourceText()+"("+args.join(",")+")";
+	};
+}
 //!steal-remove-end
 Call.prototype.closingTag = function() {
 	//!steal-remove-start
-	if(this.methodExpr[sourceTextSymbol]) {
-		return this.methodExpr[sourceTextSymbol];
+	if (process.env.NODE_ENV !== 'production') {
+		if(this.methodExpr[sourceTextSymbol]) {
+			return this.methodExpr[sourceTextSymbol];
+		}
 	}
 	//!steal-remove-end
 	return this.methodExpr.key;

--- a/expressions/hashes.js
+++ b/expressions/hashes.js
@@ -25,13 +25,15 @@ Hashes.prototype.value = function(scope, helperOptions){
 	});
 };
 //!steal-remove-start
-Hashes.prototype.sourceText = function(){
-	var hashes = [];
-	canReflect.eachKey(this.hashExprs, function(expr, prop){
-		hashes.push( prop+"="+expr.sourceText() );
-	});
-	return hashes.join(" ");
-};
+if (process.env.NODE_ENV !== 'production') {
+	Hashes.prototype.sourceText = function(){
+		var hashes = [];
+		canReflect.eachKey(this.hashExprs, function(expr, prop){
+			hashes.push( prop+"="+expr.sourceText() );
+		});
+		return hashes.join(" ");
+	};
+}
 //!steal-remove-end
 
 module.exports = Hashes;

--- a/expressions/helper.js
+++ b/expressions/helper.js
@@ -56,19 +56,21 @@ Helper.prototype.value = function(scope, helperOptions){
 			return initialValue.apply(thisArg || scope.peek("this"), args);
 		};
 		//!steal-remove-start
-		Object.defineProperty(helperFn, "name", {
-			value: canReflect.getName(this)
-		});
+		if (process.env.NODE_ENV !== 'production') {
+			Object.defineProperty(helperFn, "name", {
+				value: canReflect.getName(this)
+			});
+		}
 		//!steal-remove-end
 	}
 	//!steal-remove-start
-	else {
+	else if (process.env.NODE_ENV !== 'production') {
 		var filename = scope.peek('scope.filename');
-		var lineNumber = scope.peek('scope.lineNumber');
-		dev.warn(
-			(filename ? filename + ':' : '') +
-			(lineNumber ? lineNumber + ': ' : '') +
-			'Unable to find helper "' + methodKey + '".');
+			var lineNumber = scope.peek('scope.lineNumber');
+			dev.warn(
+				(filename ? filename + ':' : '') +
+				(lineNumber ? lineNumber + ': ' : '') +
+				'Unable to find helper "' + methodKey + '".');
 	}
 	//!steal-remove-end
 
@@ -80,24 +82,28 @@ Helper.prototype.closingTag = function() {
 };
 
 //!steal-remove-start
-Helper.prototype.sourceText = function(){
-	var text = [this.methodExpr.sourceText()];
-	if(this.argExprs.length) {
-		text.push( this.argExprs.map(function(arg){
-			return arg.sourceText();
-		}).join(" ") );
-	}
-	if(canReflect.size(this.hashExprs) > 0){
-		text.push( Hashes.prototype.sourceText.call(this) );
-	}
-	return text.join(" ");
-};
+if (process.env.NODE_ENV !== 'production') {
+	Helper.prototype.sourceText = function(){
+		var text = [this.methodExpr.sourceText()];
+		if(this.argExprs.length) {
+			text.push( this.argExprs.map(function(arg){
+				return arg.sourceText();
+			}).join(" ") );
+		}
+		if(canReflect.size(this.hashExprs) > 0){
+			text.push( Hashes.prototype.sourceText.call(this) );
+		}
+		return text.join(" ");
+	};
+}
 //!steal-remove-end
-canReflect.assignSymbols(Helper.prototype,{
-	"can.getName": function() {
-		return canReflect.getName(this.constructor) + "{{" + (this.sourceText()) + "}}";
-	}
-});
+if (process.env.NODE_ENV !== 'production') {
+	canReflect.assignSymbols(Helper.prototype,{
+		"can.getName": function() {
+			return canReflect.getName(this.constructor) + "{{" + (this.sourceText()) + "}}";
+		}
+	});
+}
 //!steal-remove-end
 
 module.exports = Helper;

--- a/expressions/literal.js
+++ b/expressions/literal.js
@@ -7,9 +7,11 @@ Literal.prototype.value = function(){
 	return this._value;
 };
 //!steal-remove-start
-Literal.prototype.sourceText = function(){
-	return JSON.stringify(this._value);
-};
+if (process.env.NODE_ENV !== 'production') {
+	Literal.prototype.sourceText = function(){
+		return JSON.stringify(this._value);
+	};
+}
 //!steal-remove-end
 
 module.exports = Literal;

--- a/expressions/lookup.js
+++ b/expressions/lookup.js
@@ -23,59 +23,63 @@ Lookup.prototype.value = function(scope, readOptions){
 	}
 
 	//!steal-remove-start
-	if (typeof value.initialValue === 'undefined' && this.key !== "debugger" && !value.parentHasKey) {
-		var filename = scope.peek('scope.filename');
-		var lineNumber = scope.peek('scope.lineNumber');
+	if (process.env.NODE_ENV !== 'production') {
+		if (typeof value.initialValue === 'undefined' && this.key !== "debugger" && !value.parentHasKey) {
+			var filename = scope.peek('scope.filename');
+			var lineNumber = scope.peek('scope.lineNumber');
 
-		var reads = observeReader.reads(this.key);
-		var firstKey = reads[0].key;
-		var key = reads.map(function(read) {
-			return read.key + (read.at ? "()" : "");
-		}).join(".");
-		var pathsForKey = scope.getPathsForKey(firstKey);
-		var paths = Object.keys( pathsForKey );
+			var reads = observeReader.reads(this.key);
+			var firstKey = reads[0].key;
+			var key = reads.map(function(read) {
+				return read.key + (read.at ? "()" : "");
+			}).join(".");
+			var pathsForKey = scope.getPathsForKey(firstKey);
+			var paths = Object.keys( pathsForKey );
 
-		var includeSuggestions = paths.length && !paths.includes(firstKey);
+			var includeSuggestions = paths.length && !paths.includes(firstKey);
 
-		var warning = [
-			(filename ? filename + ':' : '') +
-				(lineNumber ? lineNumber + ': ' : '') +
-				'Unable to find key "' + key + '".' +
-				(
-					includeSuggestions ?
-						" Did you mean" + (paths.length > 1 ? " one of these" : "") + "?\n" :
-						"\n"
-				)
-		];
+			var warning = [
+				(filename ? filename + ':' : '') +
+					(lineNumber ? lineNumber + ': ' : '') +
+					'Unable to find key "' + key + '".' +
+					(
+						includeSuggestions ?
+							" Did you mean" + (paths.length > 1 ? " one of these" : "") + "?\n" :
+							"\n"
+					)
+			];
 
-		if (includeSuggestions) {
-			paths.forEach(function(path) {
-				warning.push('\t"' + path + '" which will read from');
-				warning.push(pathsForKey[path]);
-				warning.push("\n");
-			});
+			if (includeSuggestions) {
+				paths.forEach(function(path) {
+					warning.push('\t"' + path + '" which will read from');
+					warning.push(pathsForKey[path]);
+					warning.push("\n");
+				});
+			}
+
+			warning.push("\n");
+
+			dev.warn.apply(dev,
+				warning
+			);
 		}
-
-		warning.push("\n");
-
-		dev.warn.apply(dev,
-			warning
-		);
 	}
 	//!steal-remove-end
 
 	return value;
 };
 //!steal-remove-start
-Lookup.prototype.sourceText = function(){
-	if(this[sourceTextSymbol]) {
-		return this[sourceTextSymbol];
-	} else if(this.rootExpr) {
-		return this.rootExpr.sourceText()+"."+this.key;
-	} else {
-		return this.key;
-	}
-};
+if (process.env.NODE_ENV !== 'production') {
+	Lookup.prototype.sourceText = function(){
+		if(this[sourceTextSymbol]) {
+			return this[sourceTextSymbol];
+		} else if(this.rootExpr) {
+			return this.rootExpr.sourceText()+"."+this.key;
+		} else {
+			return this.key;
+		}
+	};
+}
 //!steal-remove-end
 
 module.exports = Lookup;

--- a/helpers/-debugger-test.js
+++ b/helpers/-debugger-test.js
@@ -17,7 +17,9 @@ function mock (obj, methodName, newMethod) {
 
 var isDevelopment = false;
 //!steal-remove-start
-isDevelopment = true;
+if (process.env.NODE_ENV !== 'production') {
+	isDevelopment = true;
+}
 //!steal-remove-end
 
 unit.module('can-stache/helpers/-debugger');

--- a/helpers/-debugger.js
+++ b/helpers/-debugger.js
@@ -5,61 +5,66 @@ var evaluateArgs = noop;
 var __testing = {};
 
 //!steal-remove-start
-var canReflect = require('can-reflect');
-var canSymbol = require('can-symbol');
+if (process.env.NODE_ENV !== 'production') {
+	var canReflect = require('can-reflect');
 
-__testing = {
-	allowDebugger: true
-};
+	var canSymbol = require('can-symbol');
 
-resolveValue = function (value) {
-	if (value && value[canSymbol.for("can.getValue")]) {
-		return canReflect.getValue(value);
-	}
-	return value;
-};
+	__testing = {
+		allowDebugger: true
+	};
 
-evaluateArgs = function (left, right) {
-	switch (arguments.length) {
-		case 0: return true;
-		case 1: return !!resolveValue(left);
-		case 2: return resolveValue(left) === resolveValue(right);
-		default:
-			canLog.log([
-				'Usage:',
-				'  {{debugger}}: break any time this helper is evaluated',
-				'  {{debugger condition}}: break when `condition` is truthy',
-				'  {{debugger left right}}: break when `left` === `right`'
-			].join('\n'));
-			throw new Error('{{debugger}} must have less than three arguments');
-	}
-};
+	resolveValue = function (value) {
+		if (value && value[canSymbol.for("can.getValue")]) {
+			return canReflect.getValue(value);
+		}
+		return value;
+	};
+
+	evaluateArgs = function (left, right) {
+		switch (arguments.length) {
+			case 0: return true;
+			case 1: return !!resolveValue(left);
+			case 2: return resolveValue(left) === resolveValue(right);
+			default:
+				canLog.log([
+					'Usage:',
+					'  {{debugger}}: break any time this helper is evaluated',
+					'  {{debugger condition}}: break when `condition` is truthy',
+					'  {{debugger left right}}: break when `left` === `right`'
+				].join('\n'));
+				throw new Error('{{debugger}} must have less than three arguments');
+		}
+	};
+}
 //!steal-remove-end
 
 function debuggerHelper (left, right) {
 	//!steal-remove-start
-	var shouldBreak = evaluateArgs.apply(null, Array.prototype.slice.call(arguments, 0, -1));
-	if (!shouldBreak) {
-		return;
+	if (process.env.NODE_ENV !== 'production') {
+		var shouldBreak = evaluateArgs.apply(null, Array.prototype.slice.call(arguments, 0, -1));
+		if (!shouldBreak) {
+			return;
+		}
+
+		// jshint +W098
+		var options = arguments[arguments.length - 1];
+		var get = function (path) {
+			return options.scope.get(path);
+		};
+		// jshint -W098
+
+		canLog.log('Use `get(<path>)` to debug this template');
+
+		var allowDebugger = __testing.allowDebugger;
+		// forgotten debugger
+		// jshint -W087
+		if (allowDebugger) {
+			debugger;
+			return;
+		}
+		// jshint +W087
 	}
-
-	// jshint +W098
-	var options = arguments[arguments.length - 1];
-	var get = function (path) {
-		return options.scope.get(path);
-	};
-	// jshint -W098
-
-	canLog.log('Use `get(<path>)` to debug this template');
-
-	var allowDebugger = __testing.allowDebugger;
-	// forgotten debugger
-	// jshint -W087
-	if (allowDebugger) {
-		debugger;
-		return;
-	}
-	// jshint +W087
 	//!steal-remove-end
 
 	canLog.warn('Forgotten {{debugger}} helper');

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -196,11 +196,13 @@ var isHelper = function() {
 	}
 
 	//!steal-remove-start
-	Object.defineProperty(isHelper, "name", {
-		value: "is("+[].slice.call(args,0,2).map(function(arg){
-			return canReflect.getName(arg);
-		}).join(",")+")"
-	});
+	if (process.env.NODE_ENV !== 'production') {
+		Object.defineProperty(isHelper, "name", {
+			value: "is("+[].slice.call(args,0,2).map(function(arg){
+				return canReflect.getName(arg);
+			}).join(",")+")"
+		});
+	}
 	//!steal-remove-end
 
 	var callFn = new Observation(isHelper);
@@ -240,7 +242,9 @@ var dataHelper = function(attr, value) {
 	var data = (looksLikeOptions(value) ? value.context : value) || this;
 	return function setData(el) {
 		//!steal-remove-start
-		dev.warn('The {{data}} helper has been deprecated; use {{domData}} instead: https://canjs.com/doc/can-stache.helpers.domData.html');
+		if (process.env.NODE_ENV !== 'production') {
+			dev.warn('The {{data}} helper has been deprecated; use {{domData}} instead: https://canjs.com/doc/can-stache.helpers.domData.html');
+		}
 		//!steal-remove-end
 		domDataState.set.call( el, attr, data );
 	};
@@ -350,8 +354,10 @@ addBuiltInHelpers();
 
 var registerHelper = function(name, callback){
 	//!steal-remove-start
-	if (helpers[name]) {
-		dev.warn('The helper ' + name + ' has already been registered.');
+	if (process.env.NODE_ENV !== 'production') {
+		if (helpers[name]) {
+			dev.warn('The helper ' + name + ' has already been registered.');
+		}
 	}
 	//!steal-remove-end
 

--- a/src/expression.js
+++ b/src/expression.js
@@ -302,7 +302,9 @@ var expression = {
 		} else if (ast.type === "Bracket") {
 			var originalKey;
 			//!steal-remove-start
-			originalKey = ast[canSymbol.for("can-stache.originalKey")];
+			if (process.env.NODE_ENV !== 'production') {
+				originalKey = ast[canSymbol.for("can-stache.originalKey")];
+			}
 			//!steal-remove-end
 			return new Bracket(
 				this.hydrateAst(ast.children[0], options),
@@ -460,7 +462,9 @@ var expression = {
 				} else if (top.type === "Lookup" || top.type === "Bracket") {
 					var bracket = {type: "Bracket", root: top};
 					//!steal-remove-start
-					canReflect.setKeyValue(bracket, canSymbol.for("can-stache.originalKey"), top.key);
+					if (process.env.NODE_ENV !== 'production') {
+						canReflect.setKeyValue(bracket, canSymbol.for("can-stache.originalKey"), top.key);
+					}
 					//!steal-remove-end
 					stack.replaceTopAndPush(bracket);
 				} else if (top.type === "Call") {

--- a/src/intermediate_and_imports.js
+++ b/src/intermediate_and_imports.js
@@ -2,7 +2,9 @@ var canStacheAst = require("can-stache-ast");
 var canDev = require("can-log/dev/dev");
 
 //!steal-remove-start
-canDev.warn('can-stache/src/intermediate_and_imports is deprecated; please use can-stache-ast instead: https://github.com/canjs/can-stache-ast');
+if (process.env.NODE_ENV !== 'production') {
+	canDev.warn('can-stache/src/intermediate_and_imports is deprecated; please use can-stache-ast instead: https://github.com/canjs/can-stache-ast');
+}
 //!steal-remove-end
 
 module.exports = canStacheAst.parse;

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -155,8 +155,10 @@ var core = {
 
 		return function(scope, parentSectionNodeList){
 			//!steal-remove-start
-			scope.set('scope.filename', state.filename);
-			scope.set('scope.lineNumber', state.lineNo);
+			if (process.env.NODE_ENV !== 'production') {
+				scope.set('scope.filename', state.filename);
+				scope.set('scope.lineNumber', state.lineNo);
+			}
 			//!steal-remove-end
 			var nodeList = [this];
 			nodeList.expression = ">" + partialName;
@@ -169,8 +171,10 @@ var core = {
 					var newContext = canReflect.getValue( exprData.argExprs[0].value(scope) );
 					if(typeof newContext === "undefined") {
 						//!steal-remove-start
-						dev.warn('The context ('+ exprData.argExprs[0].key +') you passed into the' +
-							'partial ('+ partialName +') is not defined in the scope!');
+						if (process.env.NODE_ENV !== 'production') {
+							dev.warn('The context ('+ exprData.argExprs[0].key +') you passed into the' +
+								'partial ('+ partialName +') is not defined in the scope!');
+						}
 						//!steal-remove-end
 					}else{
 						scope = scope.add(newContext);
@@ -235,8 +239,10 @@ var core = {
 		// A branching renderer takes truthy and falsey renderer.
 		var branchRenderer = function branchRenderer(scope, truthyRenderer, falseyRenderer){
 			//!steal-remove-start
-			scope.set('scope.filename', state.filename);
-			scope.set('scope.lineNumber', state.lineNo);
+			if (process.env.NODE_ENV !== 'production') {
+				scope.set('scope.filename', state.filename);
+				scope.set('scope.lineNumber', state.lineNo);
+			}
 			//!steal-remove-end
 			// Check the scope's cache if the evaluator already exists for performance.
 			var evaluator = scope.__cache[fullExpression];
@@ -290,8 +296,10 @@ var core = {
 			// If this is within a tag, make sure we only get string values.
 			var stringOnly = state.tag;
 			//!steal-remove-start
-			scope.set('scope.filename', state.filename);
-			scope.set('scope.lineNumber', state.lineNo);
+			if (process.env.NODE_ENV !== 'production') {
+				scope.set('scope.filename', state.filename);
+				scope.set('scope.lineNumber', state.lineNo);
+			}
 			//!steal-remove-end
 			var nodeList = [this];
 			nodeList.expression = expressionString;
@@ -315,9 +323,11 @@ var core = {
 				observable = evaluator;
 			} else {
 				//!steal-remove-start
-				Object.defineProperty(evaluator,"name",{
-					value: "{{"+(mode || "")+expressionString+"}}"
-				});
+				if (process.env.NODE_ENV !== 'production') {
+					Object.defineProperty(evaluator,"name",{
+						value: "{{"+(mode || "")+expressionString+"}}"
+					});
+				}
 				//!steal-remove-end
 				observable = new Observation(evaluator,null,{isObservable: false});
 			}

--- a/src/text_section.js
+++ b/src/text_section.js
@@ -37,9 +37,11 @@ assign(TextSectionBuilder.prototype,{
 
 		var renderer = this.stack[0].compile();
 		//!steal-remove-start
-		Object.defineProperty(renderer,"name",{
-			value: "textSectionRenderer<"+state.tag+"."+state.attr+">"
-		});
+		if (process.env.NODE_ENV !== 'production') {
+			Object.defineProperty(renderer,"name",{
+				value: "textSectionRenderer<"+state.tag+"."+state.attr+">"
+			});
+		}
 		//!steal-remove-end
 
 		return function(scope){
@@ -47,9 +49,11 @@ assign(TextSectionBuilder.prototype,{
 				return renderer(scope);
 			}
 			//!steal-remove-start
-			Object.defineProperty(textSectionRender,"name",{
-				value: "textSectionRender<"+state.tag+"."+state.attr+">"
-			});
+			if (process.env.NODE_ENV !== 'production') {
+				Object.defineProperty(textSectionRender,"name",{
+					value: "textSectionRender<"+state.tag+"."+state.attr+">"
+				});
+			}
 			//!steal-remove-end
 			var observation = new Observation(textSectionRender, null, {isObservable: false});
 


### PR DESCRIPTION
This fixes the first part of this issue https://github.com/canjs/canjs/issues/4170 to remove debug code from the production builds.
<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
