### PR TITLE
Allow addHelper to be passed an object

### DIFF
--- a/docs/helpers/addHelper.md
+++ b/docs/helpers/addHelper.md
@@ -5,7 +5,7 @@
 @signature `stache.addHelper(name, helper)`
 
 Registers a helper with stache that always gets passed
-the value of its arguments (instead of computes).
+the value of its arguments (instead of value observables).
 Pass the name of the helper followed by the
 function to invoke.
 
@@ -20,5 +20,26 @@ stache.addHelper( "upper", function( str ) {
 
 @param {String} name The name of the helper.
 @param {can-stache.simpleHelper} helper The helper function.
+
+@signature `stache.addHelper(helpers)`
+
+Register multiple helpers with stache that always get passed
+the value of its arguments (instead of value observables).
+
+Pass an object where the key is the name of a helper and the
+value is the callback.
+
+```js
+stache.addHelper({
+	upper: function(str) {
+		return str.toUpperCase();
+	},
+	lower: function(str) {
+		return str.toLowerCase();
+	}
+});
+```
+
+@param {{}} helpers an Object of name/callback pairs.
 
 @body

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -14,7 +14,6 @@ var helpers = require("can-stache-helpers");
 
 var domData = require('can-dom-data');
 var domDataState = require('can-dom-data-state');
-
 var looksLikeOptions = function(options){
 	return options && typeof options.fn === "function" && typeof options.inverse === "function";
 };
@@ -369,6 +368,14 @@ var registerHelper = function(name, callback){
 	helpers[name] = callback;
 };
 
+var registerHelpers = function(helpers) {
+	var name, callback;
+	for(name in helpers) {
+		callback = helpers[name];
+		registerHelper(name, makeSimpleHelper(callback));
+	}
+};
+
 var makeSimpleHelper = function(fn) {
 	return function() {
 		var realArgs = [];
@@ -386,6 +393,9 @@ module.exports = {
 	registerHelper: registerHelper,
 
 	addHelper: function(name, callback) {
+		if(typeof name === "object") {
+			return registerHelpers(name);
+		}
 		return registerHelper(name, makeSimpleHelper(callback));
 	},
 

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7078,6 +7078,27 @@ function makeTest(name, doc, mutation) {
 
 	});
 
+	test("addHelper can take an object of helpers", function(){
+		var helpers = {
+			helperOne: function(){
+				return "one";
+			},
+			helperTwo: function(){
+				return "two";
+			}
+		};
+
+		stache.addHelper(helpers);
+		var template = stache("<span>{{helperOne()}}</span><span>{{helperTwo()}}</span>");
+		var frag = template();
+
+		var spanOne = frag.firstChild;
+		var spanTwo = spanOne.nextSibling;
+
+		QUnit.equal(spanOne.firstChild.nodeValue, "one");
+		QUnit.equal(spanTwo.firstChild.nodeValue, "two");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
This makes it so that addHelper can be passed an object of name/callback
pairs, facilitating passing multiple helpers at once. This is especially
for modules that export a bunch of related helpers. Fixes #552