### PR TITLE
Add addBindings

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,7 +21,8 @@
 		"start": true,
 		"stop": true,
 		"global": true,
-		"Promise": true
+		"Promise": true,
+		"Map": true
 	},
 	"strict": false,
 	"curly": true,

--- a/can-stache.js
+++ b/can-stache.js
@@ -8,6 +8,7 @@ var TextSectionBuilder = require('./src/text_section');
 var mustacheCore = require('./src/mustache_core');
 var mustacheHelpers = require('./helpers/core');
 require('./helpers/converter');
+var addBindings = require('./src/bindings');
 var getIntermediateAndImports = require('can-stache-ast').parse;
 var utils = require('./src/utils');
 var makeRendererConvertScopes = utils.makeRendererConvertScopes;
@@ -159,7 +160,7 @@ function stache (filename, template) {
 							sectionItem.tag = tag;
 						}
 						//!steal-remove-end
-						
+
 						state.sectionElementStack.push(sectionItem);
 					}
 				} else {
@@ -502,5 +503,7 @@ stache.from = mustacheCore.getTemplateById = function(id){
 stache.registerPartial = function(id, partial) {
 	templates[id] = (typeof partial === "string" ? stache(partial) : partial);
 };
+
+stache.addBindings = addBindings;
 
 module.exports = namespace.stache = stache;

--- a/docs/addBindings.md
+++ b/docs/addBindings.md
@@ -1,0 +1,22 @@
+@function can-stache.addBindings addBindings
+@description Add a set of view binding callbacks.
+@parent can-stache.static
+
+@signature `stache.addBindings(bindings)`
+
+Register a set of view bindings.
+
+```js
+const bindings = new Map();
+bindings.add(/foo/, function(el, attrData) {
+	...
+});
+
+stache.addBindings(bindings);
+```
+
+This will loop over the set of bindings and register them all with [can-view-callbacks].
+
+@param {Map|Object} bindings A key/value pair where the keys are strings or regular expressions and the values are callback functions.
+
+@body

--- a/src/bindings.js
+++ b/src/bindings.js
@@ -1,0 +1,8 @@
+var canReflect = require("can-reflect");
+var viewCallbacks = require("can-view-callbacks");
+
+module.exports = function(bindingsMap) {
+	canReflect.eachKey(bindingsMap, function(callback, exp){
+		viewCallbacks.attr(exp, callback);
+	});
+};

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7099,6 +7099,26 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(spanTwo.firstChild.nodeValue, "two");
 	});
 
+	test("AddBindings takes a map of bindings", function(){
+		var map = new Map();
+		map.set("foo", function(el, attrData) {
+			el.appendChild(DOCUMENT().createTextNode("foo"));
+		});
+		map.set(/bar/, function(el, attrData) {
+			el.appendChild(DOCUMENT().createTextNode("bar"));
+		});
+
+		stache.addBindings(map);
+		var template = stache("<span foo></span><span bar></span>");
+		var frag = template();
+
+		var firstSpan = frag.firstChild;
+		var secondSpan = firstSpan.nextSibling;
+
+		QUnit.equal(firstSpan.firstChild.nodeValue, "foo");
+		QUnit.equal(secondSpan.firstChild.nodeValue, "bar");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
This adds the new `stache.addBindings(bindings)` method used to register
bindings. can-stache-bindings, among others, will implement this method.

Closes #553