### PR TITLE
Make addBindings prefer a symbol.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -22,7 +22,8 @@
 		"stop": true,
 		"global": true,
 		"Promise": true,
-		"Map": true
+		"Map": true,
+		"WeakMap": true
 	},
 	"strict": false,
 	"curly": true,

--- a/src/bindings.js
+++ b/src/bindings.js
@@ -1,8 +1,22 @@
 var canReflect = require("can-reflect");
+var canSymbol = require('can-symbol');
 var viewCallbacks = require("can-view-callbacks");
 
+var bindingsSymbol = canSymbol.for('can.stacheBindings');
+var bindingsAdded = new WeakMap();
+
 module.exports = function(bindingsMap) {
-	canReflect.eachKey(bindingsMap, function(callback, exp){
+	var map = canReflect.getKeyValue(bindingsMap, bindingsSymbol) || bindingsMap;
+
+	// Only add bindings once.
+	if(bindingsAdded.has(map)) {
+		return;
+	} else {
+		// Would prefer to use WeakSet but IE11 doesn't support it.
+		bindingsAdded.set(map, true);
+	}
+
+	canReflect.eachKey(map, function(callback, exp){
 		viewCallbacks.attr(exp, callback);
 	});
 };

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7099,7 +7099,7 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(spanTwo.firstChild.nodeValue, "two");
 	});
 
-	test("AddBindings takes a map of bindings", function(){
+	test("addBindings takes a map of bindings", function(){
 		var map = new Map();
 		map.set("foo", function(el, attrData) {
 			el.appendChild(DOCUMENT().createTextNode("foo"));
@@ -7110,6 +7110,31 @@ function makeTest(name, doc, mutation) {
 
 		stache.addBindings(map);
 		var template = stache("<span foo></span><span bar></span>");
+		var frag = template();
+
+		var firstSpan = frag.firstChild;
+		var secondSpan = firstSpan.nextSibling;
+
+		QUnit.equal(firstSpan.firstChild.nodeValue, "foo");
+		QUnit.equal(secondSpan.firstChild.nodeValue, "bar");
+	});
+
+	test("addBindings will use can.stacheBindings symbol if available.", function(){
+		var map = new Map();
+		map.set("foo2", function(el, attrData) {
+			el.appendChild(DOCUMENT().createTextNode("foo"));
+		});
+		map.set(/bar2/, function(el, attrData) {
+			el.appendChild(DOCUMENT().createTextNode("bar"));
+		});
+
+		var bindings = {
+			bindings: map
+		};
+		bindings[canSymbol.for("can.stacheBindings")] = map;
+		stache.addBindings(bindings);
+
+		var template = stache("<span foo2></span><span bar2></span>");
 		var frag = template();
 
 		var firstSpan = frag.firstChild;


### PR DESCRIPTION
Since can-stache-bindings exports more than just its bindings, this PR
adds a symbol that is checked for as a preference. This way someone can
do:

```js
var bindings = new Map();

exports[canSymbol.for("can.stacheBindings")] = bindings;
```

And then pass this object to `stache.addBindings()`.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
