### PR TITLE
Allow multiple converters to be registered with addConverter

### DIFF
--- a/helpers/converter.js
+++ b/helpers/converter.js
@@ -19,7 +19,18 @@ function makeConverter(getterSetter){
 	};
 }
 
+var converterPackages = new WeakMap();
 helpers.addConverter = function(name, getterSetter) {
+	if(typeof name === "object") {
+		if(!converterPackages.has(name)) {
+			converterPackages.set(name, true);
+			canReflect.eachKey(name, function(getterSetter, name) {
+				helpers.addConverter(name, getterSetter);
+			});
+		}
+		return;
+	}
+
 	var helper = makeConverter(getterSetter);
 	helper.isLiveBound = true;
 	helpers.registerHelper(name, helper );

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "can-define": "^2.0.4",
     "can-queues": "^1.0.0",
     "can-simple-map": "^4.0.0",
-    "can-stache-bindings": "^4.2.6",
     "can-test-helpers": "^1.1.0",
     "can-vdom": "^4.0.0",
     "detect-cyclic-packages": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "can-define": "^2.0.4",
     "can-queues": "^1.0.0",
     "can-simple-map": "^4.0.0",
+    "can-stache-bindings": "^4.2.6",
     "can-test-helpers": "^1.1.0",
     "can-vdom": "^4.0.0",
     "detect-cyclic-packages": "^1.1.0",

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -829,6 +829,36 @@ QUnit.test("addConverter helpers push and pull multiple values", function () {
 	deepEqual(data.attr("list").attr(), [1,2,3,5], 'push converter called');
 });
 
+QUnit.test("Can register multiple converters at once with addConverter", function(){
+	QUnit.expect(2);
+	var converters = {
+		"converter-one": {
+			get: function(){
+				QUnit.ok(true, "converter-one called");
+			},
+			set: function(){}
+		},
+		"converter-two": {
+			get: function(){
+				QUnit.ok(true, "converter-two called");
+			},
+			set: function(){}
+		}
+	};
+
+	helpers.addConverter(converters);
+
+	var data = new SimpleMap({
+		person: "Matthew"
+	});
+	var scope = new Scope(data);
+	var parentExpression = expression.parse("converter-one(person)",{baseMethodType: "Call"});
+	parentExpression.value(scope).get();
+
+	parentExpression = expression.parse("converter-two(person)",{baseMethodType: "Call"});
+	parentExpression.value(scope).get();
+});
+
 test('foo().bar', function() {
 	// expression.ast
 	var ast4 = expression.ast("foo().bar");

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -41,7 +41,6 @@ var testHelpers = require('can-test-helpers');
 var canLog = require('can-log');
 var debug = require('../helpers/-debugger');
 var helpersCore = require('can-stache/helpers/core');
-require("can-stache-bindings");
 
 var browserDoc = DOCUMENT();
 
@@ -7143,29 +7142,6 @@ function makeTest(name, doc, mutation) {
 
 		QUnit.equal(firstSpan.firstChild.nodeValue, "foo");
 		QUnit.equal(secondSpan.firstChild.nodeValue, "bar");
-	});
-
-	QUnit.test("Can register multiple converters at once with addConverter", function(){
-		QUnit.expect(2);
-		var converters = {
-			"converter-one": {
-				get: function(){
-					QUnit.ok(true, "converter-one called");
-				},
-				set: function(){}
-			},
-			"converter-two": {
-				get: function(){
-					QUnit.ok(true, "converter-two called");
-				},
-				set: function(){}
-			}
-		};
-
-		stache.addConverter(converters);
-
-		var template = stache("<div><input type='text' value:bind='converter-one(person)'><input type='text' value:bind='converter-two(person)'></div>");
-		template(new DefineMap({ person: "Matthew" }));
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -4,8 +4,8 @@ require('../helpers/-debugger-test');
 require('./nodelist-test');
 require('../helpers/-each-test');
 require('./section-test');
-var stache = require('can-stache');
-var core = require('can-stache/src/mustache_core');
+var stache = require('../can-stache');
+var core = require('../src/mustache_core');
 var clone = require('steal-clone');
 var canSymbol = require("can-symbol");
 var canReflect = require("can-reflect");
@@ -41,6 +41,7 @@ var testHelpers = require('can-test-helpers');
 var canLog = require('can-log');
 var debug = require('../helpers/-debugger');
 var helpersCore = require('can-stache/helpers/core');
+require("can-stache-bindings");
 
 var browserDoc = DOCUMENT();
 
@@ -7142,6 +7143,29 @@ function makeTest(name, doc, mutation) {
 
 		QUnit.equal(firstSpan.firstChild.nodeValue, "foo");
 		QUnit.equal(secondSpan.firstChild.nodeValue, "bar");
+	});
+
+	QUnit.test("Can register multiple converters at once with addConverter", function(){
+		QUnit.expect(2);
+		var converters = {
+			"converter-one": {
+				get: function(){
+					QUnit.ok(true, "converter-one called");
+				},
+				set: function(){}
+			},
+			"converter-two": {
+				get: function(){
+					QUnit.ok(true, "converter-two called");
+				},
+				set: function(){}
+			}
+		};
+
+		stache.addConverter(converters);
+
+		var template = stache("<div><input type='text' value:bind='converter-one(person)'><input type='text' value:bind='converter-two(person)'></div>");
+		template(new DefineMap({ person: "Matthew" }));
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!


### PR DESCRIPTION
This makes it possible to register multiple converters using the
`addConverter()` syntax.

Closes #562

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
