### PR TITLE
remove mention of auto function calling

### DIFF
--- a/docs/expressions/key-lookup.md
+++ b/docs/expressions/key-lookup.md
@@ -92,22 +92,6 @@ const data1 = { some: { key: "value" } };
 // Helper -> "value"
 // Other  -> "value"
 
-// A non-observable JS object w/ a function at the end
-const data2 = { some: { key: function() {
-	return "value";
-} } };
-
-// Helper -> "value"
-// Other  -> "value"
-
-// A non-observable JS object with intermediate functions:
-const data3 = { some: function() {
-	return { key: "value" };
-} };
-
-// Helper -> "value"
-// Other  -> "value"
-
 // A observable can-map
 const data4 = { some: new Map( { key: "value" } ) };
 

--- a/docs/expressions/key-lookup.md
+++ b/docs/expressions/key-lookup.md
@@ -77,7 +77,6 @@ Furthermore keys return different values depending on the data type.
 
 In general:
 
- - Functions are called to get their return value. (Use the [can-stache/keys/at `@` operator] to prevent this).
  - Keys in helper expression arguments that find observable data return
    a [can-compute.computed] that represents the value.
  - Keys in other expressions return the value.


### PR DESCRIPTION
In 4.0, we are no longer auto calling functions in a key lookup.