### PR TITLE
Make brackets work when following a call expression

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -471,7 +471,7 @@ var expression = {
 				} else if (top.type === "Call") {
 					stack.addToAndPush(["Call"], { type: "Bracket" });
 				} else if (top === " ") {
-					stack.popUntil(["Lookup"]);
+					stack.popUntil(["Lookup", "Call"]);
 					convertToHelperIfTopIsLookup(stack);
 					stack.addToAndPush(["Helper", "Call", "Hash"], {type: "Bracket"});
 				} else {

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -541,8 +541,7 @@ test("expression.parse - [] operator", function(){
 			[
 				new expression.Arg(
 					new expression.Call(new expression.Lookup("@foo"), [], {})
-				)
-				,
+				),
 				new expression.Arg(
 					new expression.Bracket(new expression.Lookup("bar"))
 				)

--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -532,6 +532,24 @@ test("expression.parse - [] operator", function(){
 			)
 		)
 	);
+
+	exprData = expression.parse("equal(foo(), [bar])");
+	equal(exprData.argExprs.length, 2, "there are two arguments");
+	deepEqual(exprData,
+		new expression.Call(
+			new expression.Lookup("@equal"),
+			[
+				new expression.Arg(
+					new expression.Call(new expression.Lookup("@foo"), [], {})
+				)
+				,
+				new expression.Arg(
+					new expression.Bracket(new expression.Lookup("bar"))
+				)
+			],
+			{}
+		)
+	);
 });
 
 test("Bracket expression", function(){


### PR DESCRIPTION
This fixes a case like `foo(bar(), [baz])`, where the bracket expression comes after a call expression within another call expression.
