### PR TITLE
Fixes arguments passed to helpers and adds `addConverter` docs

### DIFF
--- a/docs/addConverter.md
+++ b/docs/addConverter.md
@@ -1,0 +1,94 @@
+@function can-stache.addConverter addConverter
+@description Register a helper for bidirectional value conversion.
+@parent can-stache.static
+
+
+@signature `stache.addConverter(converterName, getterSetter)`
+
+  Creates a helper that can do two-way conversion between two
+  values.  This is especially useful with
+  [can-stache-bindings.twoWay two-way bindings] like:
+
+  ```html
+  <input value:bind='stringToNumber(age)'/>
+  ```
+
+  A converter helper provides:
+
+   - a `get` method that returns the value
+    of the `left` value given the arguments passed on the `right`.
+   - a `set` method that updates one or multiple of the `right` arguments
+     computes given a new `left` value.
+
+  `stringToNumber` might converts a number (`age`)
+  to a string (`value`), and the string (`value`) to a number (`age`)
+  as follows:
+
+
+  ```js
+  import {stache, Reflect as canReflect, DefineMap} from "can";
+
+  stache.registerConverter( "stringToNumber", {
+  	get: function( numberObservable ) {
+  		return "" + canReflect.getValue(numberObservable);
+  	},
+  	set: function( string, numberObservable ) {
+  		canReflect.setValue(numberObservable, +string);
+  	}
+  } );
+
+  var data = new DefineMap({age: 36});
+  var frag = stache(`<input value:bind="age"/> Age: {{age}}`)(data);
+
+  document.body.append(frag);
+  ```
+  @codepen
+
+  @param {String} converterName The name of the converter helper.
+  @param {can-stache.getterSetter} getterSetter An object containing get() and set() functions.
+
+@body
+
+## Use
+
+> __NOTE__: Before creating your own converter, you may want to look at what’s provided by [can-stache-converters].
+
+These helpers are useful for avoiding creating [can-define/map/map] getters and setters that do similar conversions on the view model.  Instead,
+a converter can keep your viewModels more ignorant of the demands of the
+view.  Especially as the view’s most common demand is that everything
+must be converted to a string.
+
+That being said, the following is a richer example of a converter,
+but one that should probably be part of a view model.
+
+```html
+<input value:bind='hoursAndMinutes(hours, minutes)'/>
+```
+
+The following converts both ways `hours` and `minutes` to `value`.
+
+```js
+import {stache, DefineMap, queues, Reflect as canReflect} from "can";
+
+stache.addConverter( "hoursAndMinutes", {
+	get: function( hours, minutes ) {
+		return ""+canReflect.getValue( hours ) +":"+ canReflect.getValue( minutes );
+	},
+	set: function( newFullName, hours, minutes ) {
+		queues.batch.start();
+		const parts = newFullName.split( ":" );
+		canReflect.setValue( hours , +parts[0] );
+		canReflect.setValue( minutes , +parts[1] );
+		queues.batch.stop();
+	}
+} );
+
+var data = new DefineMap({hours: 3, minutes: 17});
+var frag = stache(`
+	<input value:bind="hoursAndMinutes(hours, minutes)"/>
+	Hours: {{hours}}, Minutes: {{minutes}}`
+)(data);
+
+document.body.append(frag);
+```
+@codepen

--- a/docs/expressions/expressions.md
+++ b/docs/expressions/expressions.md
@@ -2,7 +2,7 @@
 @parent can-stache.pages 2
 
 In addition to different magic tag types, stache supports different expression
-types.  These can be used in various combinations to call [can-stache.registerHelper helper methods]
+types.  These can be used in various combinations to call [can-stache.addLiveHelper helper methods]
 or [can-component.prototype.ViewModel viewModel methods].  The following is an example of all the expressions
 combined:
 

--- a/docs/helper.md
+++ b/docs/helper.md
@@ -1,7 +1,7 @@
 @typedef {function(this:can-stache.context,...*,can-stache.sectionOptions){}} can-stache.helper(arg,options) helper
 @parent can-stache.types
 
-@description A helper function passed to [can-stache.registerHelper].
+@description A helper function passed to [can-stache.addLiveHelper].
 
 Given the arguments, returns the content that should be shown in the DOM
 or a function that will be called on the DOM element the helper was

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -172,10 +172,10 @@ key1 and key2. If the result of comparison is **truthy**, the section will be re
 
 ## Registering Helpers
 
-You can register your own global helper with the `[can-stache.addHelper addHelper]` or `[can-stache.registerHelper registerHelper]` methods.
+You can register your own global helper with the `[can-stache.addHelper addHelper]` or `[can-stache.addLiveHelper addLiveHelper]` methods.
 
 `[can-stache.addHelper addHelper]` calls the registered helper function with
-values, while `[can-stache.registerHelper registerHelper]` calls the registered helper function with
+values, while `[can-stache.addLiveHelper addLiveHelper]` calls the registered helper function with
 [can-compute.computed computes] if observable data is passed. `addHelper` is
 easier to use for basic helper functionality.
 

--- a/docs/helpers/addHelper.md
+++ b/docs/helpers/addHelper.md
@@ -1,25 +1,34 @@
 @function can-stache.addHelper addHelper
-@description Register a helper that gets passed values.
+@description Register a global helper function.
 @parent can-stache.static
 
 @signature `stache.addHelper(name, helper)`
 
-Registers a helper with stache that always gets passed
-the value of its arguments (instead of value observables).
-Pass the name of the helper followed by the
-function to invoke.
+  Registers a global helper function with stache that always gets passed
+  the value of its arguments (instead of value observables like [can-stache.addLiveHelper]).
+  Pass the name of the helper followed by the
+  function to invoke. See [can-stache.Helpers] for more details on using helpers.
 
-See [can-stache.Helpers] for more details on using helpers
-and [can-stache.registerHelper] to get computes for observable values.
+  ```js
+  import {stache} from "can";
 
-```js
-stache.addHelper( "upper", function( str ) {
-	return str.toUpperCase();
-} );
-```
+  stache.addHelper( "upper", function( str ) {
+  	return str.toUpperCase();
+  } );
 
-@param {String} name The name of the helper.
-@param {can-stache.simpleHelper} helper The helper function.
+  var frag = stache(`{{ upper(name) }}`)( {name: "Justin"} );
+
+  document.body.append(frag); // Outputs: `JUSTIN`
+  ```
+  @codepen
+
+  @param {String} name The name of the helper.
+  @param {can-stache.simpleHelper} helper The helper function.  The helper function will be
+    called with a [can-stache.helperOptions] argument if the helper is called first level:
+
+    ```html
+    {{# helper() }} HI {{/ helper }}
+    ```
 
 @signature `stache.addHelper(helpers)`
 
@@ -43,3 +52,178 @@ stache.addHelper({
 @param {{}} helpers an Object of name/callback pairs.
 
 @body
+
+
+## Use
+
+Global helper functions should be used to enhance stache with useful functionality
+common to most of your application.  Examples of custom helpers might include:
+
+- Converting a raw `Date` to a more user friendly timestamp. `{{ timestamp(birthday) }}`
+- Internationalization. `{{ i18n('Hello') }}`
+- Convert markdown into HTML. `{{ markdown(comment) }}`
+
+Stache includes a number of built-in helpers, but custom helpers can be added as well.
+
+
+You can register your own global helper with the `[can-stache.addHelper addHelper]` or `[can-stache.addLiveHelper addLiveHelper]` methods.
+
+`[can-stache.addHelper addHelper]` calls the registered helper function with
+values, while `[can-stache.addLiveHelper addLiveHelper]` calls the registered helper function with
+[can-compute.computed computes] if observable data is passed. `addHelper` is
+easier to use for basic helper functionality.
+
+
+Localization is a good example of a custom helper you might implement
+in your application. The below example takes a given key and
+returns the localized value using
+[jQuery Globalize](https://github.com/jquery/globalize).
+
+```js
+stache.addHelper( "l10n", function( str, options ) {
+	return typeof Globalize !== "undefined" ?
+		Globalize.localize( str ) :
+		str;
+} );
+```
+
+In the template, invoke the helper by calling the helper
+name followed by any additional arguments.
+
+```html
+<!-- Template -->
+<span>{{ l10n('mystring') }}</span>
+```
+
+```html
+<!-- Result -->
+<span>my string localized</span>
+```
+
+## Helper Arguments
+
+The type of arguments passed to a `addHelper` function depends on how the helper was called and the values passed to the helper.  If the helper is called:
+
+- directly within the magic tags like `{{ helper() }}`, it will be called with an additional [can-stache.helperOptions] argument.
+- within another expression like `{{ outer( helper() ) }}`, it will be called with the
+  arguments visible from stache.
+
+The following demonstrates this:
+
+```js
+import {stache} from "can";
+
+stache.addHelper( "argumentsLength", function() {
+	return arguments.length;
+} );
+
+stache.addHelper( "echo", function(value) {
+	return value;
+} );
+
+var frag = stache(`
+	<p>{{ argumentsLength(0,1) }} should be 3</p>
+	<p>{{ echo( argumentsLength(0,1) ) }} should be 2</p>
+`)();
+
+document.body.append(frag);
+```
+@codepen
+
+
+### Evaluating Helpers
+
+If you want to use a helper with a [can-stache.tags.section] tag, you should  call
+`options.fn(context)` in your return statement. This will return a
+document fragment or string with the resulting evaluated subsection.
+
+Similarly, you can call `options.inverse(context)` to evaluate the
+template between an `{{else}}` tag and the closing tag.
+
+For example, when a route matches the string passed to our
+routing helper it will show/hide the text.
+
+```js
+import {stache, DefineMap} from "can";
+
+stache.addHelper( "isReady", function( status, options ) {
+
+	if ( ["new","backlog"].indexOf(status) !== -1 ) {
+		return options.fn();
+	} else {
+		return options.inverse();
+	}
+} );
+
+var data = new DefineMap({status: "new"});
+var frag = stache(`
+	{{# isReady(status) }}
+		I am ready.
+	{{else}}
+		Wait!
+	{{/ isReady }}
+
+	<select value:bind="status">
+		<option>new</option>
+		<option>backlog</option>
+		<option>assigned</option>
+		<option>complete</option>
+	</select>
+`)(data);
+
+document.body.append(frag);
+```
+@codepen
+
+__Advanced Helpers__
+
+Helpers can be passed normal objects, native objects like numbers and strings,
+as well as a hash object. The hash object will be an object literal containing
+all ending arguments using the `key=value` syntax. The hash object will be provided
+to the helper as `options.hash`. Additionally, when using [can-stache.tags.section] tags with a helper,
+you can set a custom context by passing the object instead of `this`.
+
+```js
+stache.addHelper( "exercise", function( group, action, num, options ) {
+	if ( group && group.length > 0 && action && num > 0 ) {
+		return options.fn( {
+			group: group,
+			action: action,
+			where: options.hash.where,
+			when: options.hash.when,
+			num: num
+		} );
+	} else {
+		return options.inverse( this );
+	}
+} );
+```
+
+```html
+{{#exercise(pets, 'walked', 3, where='around the block' when=time)}}
+	Along with the {{#group}}{{.}}, {{/group}}
+	we {{action}} {{where}} {{num}} times {{when}}.
+{{else}}
+	We were lazy today.
+{{/exercise}}
+```
+
+```js
+{
+	pets: [ "cat", "dog", "parrot" ],
+	time: "this morning"
+}
+```
+
+This would output:
+
+```html
+Along with the cat, dog, parrot, we walked around the block
+3 times this morning.
+```
+
+Whereas an empty data object would output:
+
+```html
+We were lazy today.
+```

--- a/docs/helpers/registerHelper.md
+++ b/docs/helpers/registerHelper.md
@@ -1,9 +1,10 @@
 @function can-stache.registerHelper registerHelper
 @description Register a helper.
-@parent can-stache.static
+@parent can-stache/deprecated
+
+@deprecated {4.0} Use [can-stache.addLiveHelper] instead.
 
 @signature `stache.registerHelper(name, helper)`
-
 
 Registers a helper function.
 Pass the name of the helper followed by the

--- a/docs/registerConverter.md
+++ b/docs/registerConverter.md
@@ -1,6 +1,9 @@
 @function can-stache.registerConverter registerConverter
 @description Register a helper for bidirectional value conversion.
-@parent can-stache.static
+@parent can-stache/deprecated
+
+@deprecated {4.0} Use [can-stache.addConverter] instead. It will always be passed
+observables, removing the need for the user to pass values with `~`.
 
 @signature `stache.registerConverter(converterName, getterSetter)`
 
@@ -9,7 +12,7 @@ values.  This is especially useful with
 [can-stache-bindings.twoWay two-way bindings] like:
 
 ```html
-<input {($value)}='numberToString(~age)'/>
+<input value:bind='numberToString(~age)'/>
 ```
 
 A converter helper provides:
@@ -25,12 +28,14 @@ as follows:
 
 
 ```js
-stache.registerConverter( "numberToString", {
-	get: function( fooCompute ) {
-		return "" + fooCompute();
+import {stache, Reflect as canReflect} from "can";
+
+stache.registerConverter( "stringToNumber", {
+	get: function( numberObservable ) {
+		return "" + canReflect.getValue(numberObservable);
 	},
-	set: function( newVal, fooCompute ) {
-		fooCompute( +newVal );
+	set: function( string, numberObservable ) {
+		canReflect.setValue(numberObservable, +string);
 	}
 } );
 ```
@@ -53,7 +58,7 @@ That being said, the following is a richer example of a converter,
 but one that should probably be part of a view model.
 
 ```handlebars
-<input {($value)}='fullName(~first, ~last)'/>
+<input value:bind='fullName(~first, ~last)'/>
 ```
 
 The following might converts both ways `first` and `last` to `value`.

--- a/docs/stache.md
+++ b/docs/stache.md
@@ -9,6 +9,7 @@
 @group can-stache/keys 4 Key Operators
 @group can-stache.htags 5 Helpers
 @group can-stache.types 6 Types
+@group can-stache/deprecated 7 Deprecated
 @package ../package.json
 
 @link ../docco/view/stache/mustache_core.html docco

--- a/docs/tags/escaped.md
+++ b/docs/tags/escaped.md
@@ -125,7 +125,7 @@ Results in:
 The `{{helper}}` syntax is used to call out to stache [can-stache.helper helper functions] functions
 that may contain more complex functionality. `helper` is a [can-stache.key key] that must match either:
 
- - a [can-stache.registerHelper registered helper function], or
+ - a [can-stache.addLiveHelper helper function], or
  - a function in the current or parent [can-stache.scopeAndContext contexts]
 
 The following example shows both cases.

--- a/docs/tags/section.md
+++ b/docs/tags/section.md
@@ -60,7 +60,7 @@ The closing tag can end with `{{/}}`.
 
 @signature `{{#HELPER_EXPRESSION}}FN{{else}}INVERSE{{/HELPER_EXPRESSION}}`
 
-Calls a [can-stache.registerHelper registered helper] or a function in the
+Calls a [can-stache.addLiveHelper helper] or a function in the
 [can-view-scope] with an additional [can-stache.helperOptions] argument
 that can call the `FN` or `INVERSE` helpers to build the content that
 should replace these tags.

--- a/expressions/call.js
+++ b/expressions/call.js
@@ -75,7 +75,10 @@ Call.prototype.value = function(scope, helperOptions){
 				if(args.hashExprs && helperOptions && helperOptions.exprData){
 					helperOptions.exprData.hashExprs = args.hashExprs;
 				}
-				args.push(helperOptions);
+				// For #581
+				if(helperOptions !== undefined) {
+					args.push(helperOptions);
+				}
 			}
 			if(arguments.length) {
 				args.unshift(new SetIdentifier(newVal));

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7174,6 +7174,20 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal( templateContext.helpers.get("foo"), foo );
 	});
 
+	QUnit.test("nested expressions get the right number of arguments (#581)", function(){
+		stache.addHelper( "argumentsLength", function() {
+			QUnit.equal(arguments.length, 2, "got the right number of arguments")
+			return arguments.length;
+		} );
+
+		stache.addHelper( "echo", function(value) {
+			return value;
+		} );
+
+		stache("<p>{{ echo( argumentsLength(0,1) ) }}</p>")();
+
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
fixes #581 and adds addConverter docs for #556

I moved `registerConverter` and `registerHelper` to a "deprecated" section.  