### PR TITLE
configurable strikes again

### DIFF
--- a/expressions/helper.js
+++ b/expressions/helper.js
@@ -59,6 +59,7 @@ Helper.prototype.value = function(scope, helperOptions){
 		//!steal-remove-start
 		if (process.env.NODE_ENV !== 'production') {
 			Object.defineProperty(helperFn, "name", {
+				configurable: true,
 				value: canReflect.getName(this)
 			});
 		}


### PR DESCRIPTION
Set the name of the helper function to be configurable so that IE won't freak out when it gets reassigned later in templating.
