### PR TITLE
more restrictive unescaping 

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -512,12 +512,10 @@ assign(stache, mustacheHelpers);
 
 stache.safeString = function(text){
 
-	return canReflect.assignSymbols({
-		toString: function () {
+	return canReflect.assignSymbols({},{
+		"can.toDOM": function(){
 			return text;
 		}
-	},{
-		"can.stacheSafeString": true
 	});
 };
 stache.async = function(source){

--- a/can-stache.js
+++ b/can-stache.js
@@ -511,11 +511,14 @@ function stache (filename, template) {
 assign(stache, mustacheHelpers);
 
 stache.safeString = function(text){
-	return {
+
+	return canReflect.assignSymbols({
 		toString: function () {
 			return text;
 		}
-	};
+	},{
+		"can.stacheSafeString": true
+	});
 };
 stache.async = function(source){
 	var iAi = getIntermediateAndImports(source);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "can-dom-data": "^1.0.1",
     "can-dom-data-state": "^1.0.0",
     "can-dom-mutate": "^1.0.0",
-    "can-fragment": "^1.0.0",
+    "can-fragment": "^1.3.0",
     "can-globals": "^1.1.1",
     "can-import-module": "^1.0.0",
     "can-join-uris": "^1.0.0",

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7065,6 +7065,18 @@ function makeTest(name, doc, mutation) {
 
 	});
 
+	QUnit.test("null does not trigger unescape (#600)", function(){
+
+		var map = new SimpleMap({
+			foo: null
+		});
+		var frag = stache("<div>{{foo}}</div>")(map);
+		map.set("foo", "<p></p>");
+
+		QUnit.equal( frag.firstChild.getElementsByTagName("p").length, 0, "no paragraphs");
+
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7077,6 +7077,35 @@ function makeTest(name, doc, mutation) {
 
 	});
 
+	testHelpers.dev.devOnlyTest("Arrays warn about escaping (#600)", 3, function () {
+
+		var map = new SimpleMap({
+			foo: ["<p></p>"]
+		});
+
+		var teardown = testHelpers.dev.willWarn(/stache.safeString/, function(message, matched) {
+			if(matched) {
+				ok(true, "received warning");
+			}
+		});
+
+
+		var frag = stache("<div>{{foo}}</div>")(map);
+		teardown();
+
+		QUnit.equal( frag.firstChild.getElementsByTagName("p").length, 0, "no paragraphs");
+
+
+		map = new SimpleMap({
+			foo: stache.safeString(["<p></p>"])
+		});
+
+		frag = stache("<div>{{foo}}</div>")(map);
+
+		QUnit.equal( frag.firstChild.getElementsByTagName("p").length, 1, "paragraphs");
+
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
for #600

This only allows `{{}}` to insert HTML (as apposed to escaped text) when an object with either a:

- `can.viewInsert` symbol - used by `Component`
- `can.toDOM` symbol - Used now by `stache.safeString(text)` and `can-fragment`
- `nodeType` property - Used to detect HTML has been passed.  If an object with a `nodeType` is returned, that's ok because it will error when inserted in the DOM.


This might break apps as previously rendering something like:

```
{{someHelper}}

someHelper(){
  return ["<p>Hello</p>","there"]
}
```

Would result in HTML being inserted.


However, I added a warning that people now would need to use `stache.safeString()` like:

```
{{someHelper}}

someHelper(){
  return stache.safeString(["<p>Hello</p>","there"])
}
```

To get the old behavior.



I don't think we should release this as a MAJOR though for a few reasons:

- This "returning arrays" ability isn't documented AFAIK
- This "returning arrays" wasn't tested
- This "returning arrays" is broken for security reasons.  Someone should have to opt into it instead of making a possible mistake.
- If anyone is using this, they will see a nice warning with filename/lineNumber ... with the solution, making the fix straightforward.

