### PR TITLE
Handle namespace attributes for svg

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -43,7 +43,16 @@ var svgNamespace = "http://www.w3.org/2000/svg";
 var namespaces = {
 	"svg": svgNamespace,
 	// this allows a partial to start with g.
-	"g": svgNamespace
+	"g": svgNamespace,
+	"defs": svgNamespace,
+	"path": svgNamespace,
+	"filter": svgNamespace, 
+	"feMorphology": svgNamespace,
+	"feGaussianBlur": svgNamespace,
+	"feOffset": svgNamespace,
+	"feComposite": svgNamespace,
+	"feColorMatrix": svgNamespace,
+	"use": svgNamespace
 },
 	textContentOnlyTag = {style: true, script: true};
 
@@ -370,6 +379,11 @@ function stache (filename, template) {
 			var section = state.node.section || state.attr.section;
 			if(section){
 				section.add(value);
+			} else if (value === svgNamespace) {
+				state.attr.value = {
+					value: value,
+					namespaceURI: 'http://www.w3.org/2000/xmlns/'
+				};
 			} else {
 				state.attr.value += value;
 			}

--- a/can-stache.js
+++ b/can-stache.js
@@ -39,7 +39,9 @@ if(!viewCallbacks.tag("content")) {
 
 var wrappedAttrPattern = /[{(].*[)}]/;
 var colonWrappedAttrPattern = /^on:|(:to|:from|:bind)$|.*:to:on:.*/;
-var svgNamespace = "http://www.w3.org/2000/svg";
+var svgNamespace = "http://www.w3.org/2000/svg",
+xmlnsAttrNamespaceURI = "http://www.w3.org/2000/xmlns/",
+xlinkHrefAttrNamespaceURI =  "http://www.w3.org/1999/xlink";
 var namespaces = {
 	"svg": svgNamespace,
 	// this allows a partial to start with g.
@@ -54,6 +56,10 @@ var namespaces = {
 	"feColorMatrix": svgNamespace,
 	"use": svgNamespace
 },
+	attrsNamespacesURI = {
+		'xmlns': xmlnsAttrNamespaceURI,
+		'xlink:href': xlinkHrefAttrNamespaceURI
+	},
 	textContentOnlyTag = {style: true, script: true};
 
 function stache (filename, template) {
@@ -332,6 +338,7 @@ function stache (filename, template) {
 
 		},
 		attrEnd: function(attrName, lineNo){
+			var matchedAttrNamespacesURI = attrsNamespacesURI[attrName];
 			if(state.node.section) {
 				state.node.section.add("\" ");
 			} else {
@@ -339,8 +346,16 @@ function stache (filename, template) {
 					state.node.attrs = {};
 				}
 
-				state.node.attrs[state.attr.name] =
-					state.attr.section ? state.attr.section.compile(copyState()) : state.attr.value;
+				if (state.attr.section) {
+					state.node.attrs[state.attr.name] = state.attr.section.compile(copyState());
+				} else if (matchedAttrNamespacesURI) {
+					state.node.attrs[state.attr.name] = {
+						value: state.attr.value, 
+						namespaceURI: attrsNamespacesURI[attrName]
+					};
+				} else {
+					state.node.attrs[state.attr.name] = state.attr.value;
+				}
 
 				var attrCallback = viewCallbacks.attr(attrName);
 
@@ -379,11 +394,6 @@ function stache (filename, template) {
 			var section = state.node.section || state.attr.section;
 			if(section){
 				section.add(value);
-			} else if (value === svgNamespace) {
-				state.attr.value = {
-					value: value,
-					namespaceURI: 'http://www.w3.org/2000/xmlns/'
-				};
 			} else {
 				state.attr.value += value;
 			}

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7107,27 +7107,19 @@ function makeTest(name, doc, mutation) {
 	});
 
 	QUnit.test("SVGs are not rendered correctly", function() {
-		var svg = '<svg width="233" height="233" viewBox="0 0 233 233" xmlns="http://www.w3.org/2000/svg">\
-				<defs>\
-					<path id="h-shape" d="M0 0h82.457v79.8h67.613V0H233v233h-82.93v-70.012H82.457V233H0z" />\
-					<filter x="-6.4%" y="-6.4%" width="112.9%" height="112.9%" filterUnits="objectBoundingBox" id="h-shape-shadow">\
-						<feMorphology radius="5" in="SourceAlpha" result="shadowSpreadInner1" />\
-						<feGaussianBlur stdDeviation="12.5" in="shadowSpreadInner1" result="shadowBlurInner1" />\
-						<feOffset in="shadowBlurInner1" result="shadowOffsetInner1" />\
-						<feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"\
-						/>\
-						<feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" in="shadowInnerInner1" />\
-					</filter>\
-				</defs>\
-				<g fill="none" fill-rule="evenodd">\
-					<use fill="#000" filter="url(#h-shape-shadow)" xlink:href="#h-shape" />\
-					<path stroke="#000" stroke-width="10" d="M5 5v223h72.457v-70.012h77.613V228H228V5h-72.93v79.8H77.457V5H5z" stroke-linejoin="square"\
-					/>\
-				</g>\
-			</svg>';
+		var svg = '<svg width="50" height="50" xmlns="http://www.w3.org/2000/svg">' +
+		'<path id="h-shape" d="M0 0h82.457v79.8h67.613V0H233v233h-82.93v-70.012H82.457V233H0z" />' +
+		'<circle r="25" cx="25" cy="25"></circle>' +
+		'<use xlink:href="#h-shape" />' +
+		'</svg>';
 
 		var frag = stache(svg)({});
-		QUnit.equal(frag.children[0].getAttributeNS("http://www.w3.org/2000/xmlns/", 'xmlns'), "http://www.w3.org/2000/svg", "xmlns attr");
+		var svgTag = frag.firstChild;
+		var useTag = frag.firstChild.getElementsByTagName('use')[0];
+
+		QUnit.equal(svgTag.getAttributeNS("http://www.w3.org/2000/xmlns/", 'xmlns'), "http://www.w3.org/2000/svg", "xmlns attr");
+		QUnit.equal(useTag.getAttributeNS("http://www.w3.org/1999/xlink", 'href'), "#h-shape", "xlink:href attr");
+
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7106,6 +7106,30 @@ function makeTest(name, doc, mutation) {
 
 	});
 
+	QUnit.test("SVGs are not rendered correctly", function() {
+		var svg = '<svg width="233" height="233" viewBox="0 0 233 233" xmlns="http://www.w3.org/2000/svg">\
+				<defs>\
+					<path id="h-shape" d="M0 0h82.457v79.8h67.613V0H233v233h-82.93v-70.012H82.457V233H0z" />\
+					<filter x="-6.4%" y="-6.4%" width="112.9%" height="112.9%" filterUnits="objectBoundingBox" id="h-shape-shadow">\
+						<feMorphology radius="5" in="SourceAlpha" result="shadowSpreadInner1" />\
+						<feGaussianBlur stdDeviation="12.5" in="shadowSpreadInner1" result="shadowBlurInner1" />\
+						<feOffset in="shadowBlurInner1" result="shadowOffsetInner1" />\
+						<feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"\
+						/>\
+						<feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" in="shadowInnerInner1" />\
+					</filter>\
+				</defs>\
+				<g fill="none" fill-rule="evenodd">\
+					<use fill="#000" filter="url(#h-shape-shadow)" xlink:href="#h-shape" />\
+					<path stroke="#000" stroke-width="10" d="M5 5v223h72.457v-70.012h77.613V228H228V5h-72.93v79.8H77.457V5H5z" stroke-linejoin="square"\
+					/>\
+				</g>\
+			</svg>';
+
+		var frag = stache(svg)({});
+		QUnit.equal(frag.children[0].getAttributeNS("http://www.w3.org/2000/xmlns/", 'xmlns'), "http://www.w3.org/2000/svg", "xmlns attr");
+	});
+
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -7105,20 +7105,24 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal( frag.firstChild.getElementsByTagName("p").length, 1, "paragraphs");
 
 	});
-
+	
 	QUnit.test("SVGs are not rendered correctly", function() {
-		var svg = '<svg width="50" height="50" xmlns="http://www.w3.org/2000/svg">' +
-		'<path id="h-shape" d="M0 0h82.457v79.8h67.613V0H233v233h-82.93v-70.012H82.457V233H0z" />' +
-		'<circle r="25" cx="25" cy="25"></circle>' +
-		'<use xlink:href="#h-shape" />' +
-		'</svg>';
+		if(doc.createElementNS) {
+			var svg = '<svg width="50" height="50" xmlns="http://www.w3.org/2000/svg">' +
+			'<path id="h-shape" d="M0 0h82.457v79.8h67.613V0H233v233h-82.93v-70.012H82.457V233H0z" />' +
+			'<circle r="25" cx="25" cy="25"></circle>' +
+			'<use xlink:href="#h-shape" />' +
+			'</svg>';
 
-		var frag = stache(svg)({});
-		var svgTag = frag.firstChild;
-		var useTag = frag.firstChild.getElementsByTagName('use')[0];
+			var frag = stache(svg)({});
+			var svgTag = frag.firstChild;
+			var useTag = frag.firstChild.getElementsByTagName('use')[0];
 
-		QUnit.equal(svgTag.getAttributeNS("http://www.w3.org/2000/xmlns/", 'xmlns'), "http://www.w3.org/2000/svg", "xmlns attr");
-		QUnit.equal(useTag.getAttributeNS("http://www.w3.org/1999/xlink", 'href'), "#h-shape", "xlink:href attr");
+			QUnit.equal(svgTag.getAttributeNS("http://www.w3.org/2000/xmlns/", 'xmlns'), "http://www.w3.org/2000/svg", "xmlns attr");
+			QUnit.equal(useTag.getAttributeNS("http://www.w3.org/1999/xlink", 'href'), "#h-shape", "xlink:href attr");
+		} else {
+			expect(0);
+		}
 
 	});
 


### PR DESCRIPTION
For #584, once this PR https://github.com/canjs/can-view-target/pull/69 is merged and released the tests should will be passing. 