### PR TITLE
Use the current scope in the falsey for/of

### DIFF
--- a/helpers/-for-of-test.js
+++ b/helpers/-for-of-test.js
@@ -143,3 +143,12 @@ QUnit.test("for(value of object) works in a string", function(){
 
 	QUnit.equal( frag.firstChild.className, "[first-FIRST][second-SECOND]");
 });
+
+QUnit.test("else contains the correct this", function() {
+	var template = stache("{{#for(item of items)}}ITEM{{else}}{{this.message}}{{/for}}");
+	var frag = template({
+		items: [],
+		message: "empty"
+	});
+	QUnit.equal(frag.firstChild.nextSibling.nodeValue, "empty", "got the value from the VM");
+});

--- a/helpers/-for-of.js
+++ b/helpers/-for-of.js
@@ -114,7 +114,7 @@ var forHelper = function(helperOptions) {
 			};
 
 			live.list(el, items, cb, options.context, el.parentNode, nodeList, function(list, parentNodeList){
-				return options.inverse(options.scope.add(list), options.options, parentNodeList);
+				return options.inverse(options.scope, options.options, parentNodeList);
 			});
 		};
 	}


### PR DESCRIPTION
When in an `{{else}}` for a for/of, the inverse template should be
rendered with the current scope. Fixes #621