### PR TITLE
fixing tests using Symbols for IE11

### DIFF
--- a/test/expression-test.js
+++ b/test/expression-test.js
@@ -523,7 +523,8 @@ test("expression.parse - [] operator", function(){
 	deepEqual(expression.parse("foo['bar']"),
 		new expression.Bracket(
 			new expression.Literal('bar'),
-			new expression.Lookup('foo')
+			new expression.Lookup('foo'),
+			'foo'
 		),
 		"foo['bar']"
 	);
@@ -531,7 +532,8 @@ test("expression.parse - [] operator", function(){
 	deepEqual(expression.parse("foo[bar]"),
 		new expression.Bracket(
 			new expression.Lookup('bar'),
-			new expression.Lookup('foo')
+			new expression.Lookup('foo'),
+			'foo'
 		),
 		"foo[bar]"
 	);
@@ -556,7 +558,8 @@ test("expression.parse - [] operator", function(){
 				[],
 				{}
 			),
-			new expression.Lookup('foo')
+			new expression.Lookup('foo'),
+			'foo'
 		)
 	);
 


### PR DESCRIPTION
IE11 does not support Symbols, so can-symbol falls back to using string
keys. These keys are included when running deepEqual on the result of
expression.parse, whereas they are not when Symbols are used. To fix
these tests, I included the value stored to these keys in the expected
value that is passed to deepEqual.

part of https://github.com/canjs/canjs/issues/4115.