### PR TITLE
615 stache literal magic tags

### DIFF
--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -94,6 +94,8 @@ var core = {
 			value = exprData.value(scope);
 		} else if (exprData instanceof expression.Lookup) {
 			value = exprData.value(scope);
+		} else if (exprData instanceof expression.Literal) {
+			value = exprData.value.bind(exprData);
 		} else if (exprData instanceof expression.Helper && exprData.methodExpr instanceof expression.Bracket) {
 			// Brackets get wrapped in Helpers when used in attributes
 			// like `<p class="{{ foo[bar] }}" />`
@@ -303,9 +305,7 @@ var core = {
 	makeLiveBindingBranchRenderer: function(mode, expressionString, state){
 		// Pre-process the expression.
 		var exprData = core.expression.parse(expressionString);
-		if(!(exprData instanceof expression.Helper) && !(exprData instanceof expression.Call) && !(exprData instanceof expression.Bracket) && !(exprData instanceof expression.Lookup)) {
-			exprData = new expression.Helper(exprData,[],{});
-		}
+
 		// A branching renderer takes truthy and falsey renderer.
 		var branchRenderer = function branchRenderer(scope, parentSectionNodeList, truthyRenderer, falseyRenderer){
 			// If this is within a tag, make sure we only get string values.

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -1452,7 +1452,7 @@ function makeTest(name, doc, mutation) {
 			"if": "{{#if test}}if{{else}}else{{/if}}",
 			"not_if": "not_{{^if test}}not{{/if}}if",
 			"each": "{{#each test}}{{.}}{{/each}}",
-			"with": "wit{{#with test}}<span>{{3}}</span>{{/with}}"
+			"with": "wit{{#with test}}<span>{{[3]}}</span>{{/with}}"
 		};
 
 		var template = stache("There are {{ length }} todos");
@@ -6439,6 +6439,23 @@ function makeTest(name, doc, mutation) {
 
 		div.appendChild(frag);
 		QUnit.equal(innerHTML(div).trim(), 'matt');
+	});
+
+	QUnit.test("Literals in magic tags #615", function() {
+		var template = stache("<div data-value=\"{{1}}\">{{0}} - {{1}}</div>");
+		var map = new DefineMap({
+			"0": "Hello",
+			"1": "World"
+		});
+
+		var section = doc.createElement("section");
+		var frag = template(map);
+
+		section.appendChild(frag);
+
+		var div = section.firstChild;
+		QUnit.equal(div.getAttribute('data-value'), 1, "has the literal value");
+		QUnit.equal(innerHTML(div).trim(), '0 - 1');
 	});
 
 	// PUT NEW TESTS RIGHT BEFORE THIS!


### PR DESCRIPTION
Closes - https://github.com/canjs/can-stache/issues/615

Fixes issue with attributes using `makeStringBranchRenderer`, was using `makeEvaluator` which was returning the literal value rather than a value getter.