### PR TITLE
Portals

### DIFF
--- a/docs/helpers/portal.md
+++ b/docs/helpers/portal.md
@@ -25,7 +25,7 @@ console.log(document.head.innerHTML)
 ```
 
 @param {can-stache/expressions/key-lookup|can-stache/expressions/call} EXPRESSION An
-expression that returns an *element*. If the value of the `EXPRESSION` is observable, the resulting HTML will be reattached to which underlying element it points to.
+expression that returns an *element*. If the value of the `EXPRESSION` is observable, the resulting HTML will be *moved* when the value of the observable changes to a different element.
 
 @param {can-stache.sectionRenderer} FN A subsection that is
 rendered to the value in `EXPRESSION`.
@@ -34,7 +34,7 @@ rendered to the value in `EXPRESSION`.
 
 ## Use
 
-`portal` is used to render HTML some place other than the template from which the helper is used.
+`portal` is used to render HTML some place other than the template in which the helper is used.
 
 A common use case for `portal` is to render content with the document's [head](https://developer.mozilla.org/en-US/docs/Web/API/Document/head) element.
 

--- a/docs/helpers/portal.md
+++ b/docs/helpers/portal.md
@@ -1,0 +1,63 @@
+@function can-stache.portal portal
+@parent can-stache.htags 6
+
+@signature `{{#portal(EXPRESSION)}}FN{{/portal}}`
+
+`portal` is used to insert a section of a template into another element, and not at the place where the helper is used.
+
+```js
+import {stache} from "can";
+
+let view = stache(`
+	{{#portal(head)}}
+		<title>My website!</title>
+		<meta og:title="My website">
+	{{/portal}}
+`);
+
+let data = {
+	head: document.head
+};
+
+view(data);
+console.log(document.head.innerHTML)
+// -> <title>My website!</title>\n<meta og:title="My website">
+```
+
+@param {can-stache/expressions/key-lookup|can-stache/expressions/call} EXPRESSION An
+expression that returns an *element*. If the value of the `EXPRESSION` is observable, the resulting HTML will be reattached to which underlying element it points to.
+
+@param {can-stache.sectionRenderer} FN A subsection that is
+rendered to the value in `EXPRESSION`.
+
+@body
+
+## Use
+
+`portal` is used to render HTML some place other than the template from which the helper is used.
+
+A common use case for `portal` is to render content with the document's [head](https://developer.mozilla.org/en-US/docs/Web/API/Document/head) element.
+
+For components, this makes it easier to have separate `<title>` and `<meta>` tags defined in each template.
+
+For example this component:
+
+```js
+import { Component } from "can";
+
+Component.extend({
+	tag: "cart-page",
+	view: `
+		{{#portal(head)}}
+		<title>Cart | Dog Stuff</title>
+		{{/portal}}
+	`,
+	ViewModel: {
+		head: {
+			default: () => document.head
+		}
+	}
+});
+```
+
+Will insert `<title>Cart | Dog Stuff</title>` into the document head.

--- a/helpers/-portal-test.js
+++ b/helpers/-portal-test.js
@@ -1,0 +1,98 @@
+var QUnit = require("steal-qunit");
+var stache = require("can-stache");
+var DefineMap = require("can-define/map/map");
+var globals = require("can-globals");
+var domMutate = require("can-dom-mutate");
+var domMutateNode = require("can-dom-mutate/node");
+
+require("./-portal");
+
+QUnit.module("can-stache #portal helper");
+
+test("basics", function(){
+	var el = document.createElement("div");
+	var template = stache("{{#portal(root)}}hello {{name}}{{/portal}}");
+	var vm = new DefineMap({name: "Matthew", root: el});
+
+	template(vm);
+	equal(el.firstChild.nextSibling.nodeValue, "Matthew");
+
+	vm.name ="Wilbur";
+	equal(el.firstChild.nextSibling.nodeValue, "Wilbur");
+});
+
+test("element is observable", function(){
+	var el = document.createElement("div");
+	var template = stache("{{#portal(root)}}{{name}}{{/}}");
+	var vm = new DefineMap({name: "Matthew", root: null});
+
+	template(vm);
+
+	vm.root = el;
+	equal(el.firstChild.nodeValue, "Matthew");
+});
+
+test("element changes", function() {
+	var one = document.createElement("div");
+	var two = document.createElement("div");
+
+	var template = stache("{{#portal(root)}}{{name}}{{/}}");
+	var vm = new DefineMap({name: "Matthew", root: one});
+
+	template(vm);
+	equal(one.firstChild.nodeValue, "Matthew");
+
+	vm.root = two;
+	equal(two.firstChild.nodeValue, "Matthew");
+	equal(one.firstChild, null, "One had its children removed");
+});
+
+test("tears down when the element is removed", function() {
+	var doc = document.implementation.createHTMLDocument("test");
+	globals.setKeyValue("document", doc);
+
+	var el = doc.createElement("div");
+	domMutateNode.appendChild.call(doc.body, el);
+
+	var template = stache("{{#portal(root)}}{{name}}{{/}}");
+	var vm = new DefineMap({name: "Matthew", root: el});
+
+	template(vm);
+	equal(el.firstChild.nodeValue, "Matthew");
+
+	domMutate.onNodeRemoval(el, function() {
+		equal(el.firstChild, null, "removed when parent removed");
+		start();
+	});
+
+	stop();
+	domMutateNode.removeChild.call(doc.body, el);
+});
+
+test("conditionally rendering a portal", function() {
+	var one = document.createElement("div");
+	var two = document.createElement("span");
+
+	var template = stache("{{#eq(page, 'one')}}{{#portal(this.one)}}{{name}}{{/portal}}{{/eq}}" +
+		"{{#eq(page, 'two')}}{{#portal(this.two)}}{{name}}{{/portal}}{{/eq}}");
+	var vm = new DefineMap({page: "one", name: "Matthew", one: one, two: two});
+
+	template(vm);
+	equal(one.firstChild.nodeValue, "Matthew");
+	equal(two.firstChild, null, "nothing rendered to two");
+
+	vm.page = "two";
+	equal(one.firstChild, null, "nothing rendered to one");
+	equal(two.firstChild.nodeValue, "Matthew");
+});
+
+test("Doesn't mess with existing DOM", function() {
+	var el = document.createElement("div");
+	el.appendChild(document.createTextNode("Hello"));
+	var template = stache("{{#portal(root)}}{{name}}{{/portal}}");
+	var vm = new DefineMap({name: "Matthew", root: el});
+
+	template(vm);
+	equal(el.firstChild.nodeValue, "Hello", "existing content left alone");
+	equal(el.firstChild.nextSibling.nodeValue, "Matthew");
+});

--- a/helpers/-portal.js
+++ b/helpers/-portal.js
@@ -54,8 +54,9 @@ function portalHelper(elementObservable, options){
 	getElementAndRender();
 
 	return function(el) {
-		var comment = getDocument().createComment("portal(" + canReflect.getName(elementObservable) + ")");
-		var frag = getDocument().createDocumentFragment();
+		var doc = getDocument();
+		var comment = doc.createComment("portal(" + canReflect.getName(elementObservable) + ")");
+		var frag = doc.createDocumentFragment();
 		domMutateNode.appendChild.call(frag, comment);
 		nodeLists.replace([el], frag);
 

--- a/helpers/-portal.js
+++ b/helpers/-portal.js
@@ -1,0 +1,72 @@
+var canReflect = require("can-reflect");
+var live = require("can-view-live");
+var nodeLists = require("can-view-nodelist");
+var Observation = require("can-observation");
+var getDocument = require("can-globals/document/document");
+var domMutate = require("can-dom-mutate");
+var domMutateNode = require("can-dom-mutate/node");
+
+function portalHelper(elementObservable, options){
+	function evaluator() {
+		return options.fn(
+			options.scope
+			.addLetContext({}),
+			options.options
+		);
+	}
+
+	var el, nodeList;
+	function teardown() {
+		if(el) {
+			canReflect.offValue(elementObservable, getElementAndRender);
+			el = null;
+		}
+
+		if(nodeList) {
+			nodeLists.remove(nodeList);
+			nodeList = null;
+		}
+	}
+
+	function getElementAndRender() {
+		teardown();
+		el = canReflect.getValue(elementObservable);
+
+		if(el) {
+			var node = getDocument().createTextNode("");
+			domMutateNode.appendChild.call(el, node);
+
+			// make a child nodeList inside the can.view.live.html nodeList
+			// so that if the html is re
+			nodeList = [node];
+			nodeList.expression = "live.html";
+			nodeLists.register(nodeList, null, null, true);
+
+			var observable = new Observation(evaluator, null, {isObservable: false});
+
+			live.html(node, observable, el, nodeList);
+
+			canReflect.onValue(elementObservable, getElementAndRender);
+			domMutate.onNodeRemoval(el, teardown);
+		}
+	}
+
+	getElementAndRender();
+
+	return function(el) {
+		var comment = getDocument().createComment("portal(" + canReflect.getName(elementObservable) + ")");
+		var frag = getDocument().createDocumentFragment();
+		domMutateNode.appendChild.call(frag, comment);
+		nodeLists.replace([el], frag);
+
+		var nodeList = [comment];
+		nodeList.expression = "portal";
+		nodeLists.register(nodeList, teardown, options.nodeList, true);
+		nodeLists.update(options.nodeList, [comment]);
+	};
+}
+
+portalHelper.isLiveBound = true;
+portalHelper.requiresOptionsArgument = true;
+
+module.exports = portalHelper;

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -19,6 +19,7 @@ var domDataState = require('can-dom-data-state');
 
 var forHelper = require("./-for-of");
 var letHelper = require("./-let");
+var portalHelper = require("./-portal");
 
 var builtInHelpers = {};
 var builtInConverters = {};
@@ -102,7 +103,7 @@ var helpersCore = {
 			}
 			return;
 		}
-	
+
 		var helper = makeConverter(getterSetter);
 		helper.isLiveBound = true;
 		helpersCore.registerHelper(name, helper);
@@ -132,7 +133,7 @@ var helpersCore = {
 		}
 		// Clear converterPackages map before re-adding converters
 		converterPackages.delete(builtInConverters);
-		
+
 		helpersCore.addBuiltInHelpers();
 		helpersCore.addBuiltInConverters();
 	},
@@ -361,7 +362,7 @@ var eachHelper = function(items) {
 			hashOptions[exprs.key] = key;
 		});
 	}
-	
+
 	if ((
 		canReflect.isObservableLike(resolved) && canReflect.isListLike(resolved) ||
 			( canReflect.isListLike(resolved) && canReflect.isValueLike(items) )
@@ -533,7 +534,8 @@ assign(builtInHelpers, {
 	and: andHelper,
 	or: orHelper,
 	'let': letHelper,
-	'for': forHelper
+	'for': forHelper,
+	portal: portalHelper
 });
 
 assign(builtInConverters, {

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -9,6 +9,7 @@ require('../helpers/-for-of-test');
 require('../helpers/-let-test');
 require('../helpers/-each-test');
 require('../helpers/-converter-test');
+require('../helpers/-portal-test');
 require('./section-test');
 require("./partials-test");
 require("./filename-test");


### PR DESCRIPTION
This adds support for portals as described in #646

Portals are a way to attach HTML somewhere other than within the
template. This is commonly used for injecting modals into the
document.body, or for adding metadata such as the `document.head`.

In the implementation portals are always *appended* to the host element.
This means they don't destroy any DOM already there. When a template is
removed the DOM portaled to the other element will be removed.

Closes #646.