### PR TITLE
Prevents bracket operator observables creation from leaking observation records 

### DIFF
--- a/helpers/-let-test.js
+++ b/helpers/-let-test.js
@@ -1,8 +1,10 @@
 var QUnit = require("steal-qunit");
 var stache = require("can-stache");
 var DefineMap = require("can-define/map/map");
+var SimpleMap = require("can-simple-map");
 var Scope = require("can-view-scope");
 var helpersCore = require('can-stache/helpers/core');
+window.queues = require("can-queues");
 
 require("./-let");
 
@@ -83,4 +85,29 @@ QUnit.test("let works after calling helpersCore.__resetHelpers", function() {
 	vm.name = "Ramiya";
 
 	QUnit.equal( frag.lastChild.innerHTML, "Ramiya", "value updated");
+});
+
+QUnit.test("let multiple updates (#650)", function(){
+
+	// This is actually testing that creating the prop[ref] observable will not leak an observation record.
+	var template = stache(
+		"{{let a = prop[ref]}}"+
+		"{{a}}"
+	);
+
+	var data = new SimpleMap({
+		ref: 0,
+		prop: new SimpleMap({
+			0: 1,
+			1: 2,
+			2: 3,
+			4: 4
+		})
+	});
+
+	template(data);
+
+	data.set("ref", data.get("ref")+1 );
+	data.set("ref", data.get("ref")+1 );
+	QUnit.ok(true, "got here");
 });

--- a/src/expression-helpers.js
+++ b/src/expression-helpers.js
@@ -5,6 +5,7 @@ var Literal = require("../expressions/literal");
 var canReflect = require("can-reflect");
 var stacheKey = require("can-stache-key");
 var Observation = require("can-observation");
+var ObservationRecorder = require("can-observation-recorder");
 var makeComputeLike = require("can-view-scope/make-compute-like");
 var SetterObservable = require("can-simple-observable/setter/setter");
 
@@ -25,7 +26,9 @@ function getObservableValue_fromDynamicKey_fromObservable(key, root, helperOptio
 	});
 	// This prevents lazy evalutaion
 	Observation.temporarilyBind(computeValue);
-	computeValue.initialValue = canReflect.getValue(computeValue);
+
+	// peek so no observable that might call getObservableValue_fromDynamicKey_fromObservable will re-evaluate if computeValue changes.
+	computeValue.initialValue = ObservationRecorder.peekValue(computeValue);
 	computeValue.parentHasKey = parentHasKey;
 	// Todo:
 	// 1. We should warn here if `initialValue` is undefined.  We can expose the warning function


### PR DESCRIPTION
fixes #650

Creating the observable for something like `foo[bar]` was leaking a read to that observable.  This could cause infinite recursion. 

