### PR TITLE
add support for non-strictly created tag warnings by falling back to …

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -177,7 +177,7 @@ function stache (filename, template) {
 						//!steal-remove-start
 						if (process.env.NODE_ENV !== 'production') {
 							var tag = typeof renderer.exprData.closingTag === 'function' ?
-								renderer.exprData.closingTag() : '';
+								renderer.exprData.closingTag() : stache;
 							sectionItem.tag = tag;
 						}
 						//!steal-remove-end

--- a/test/warnings-test.js
+++ b/test/warnings-test.js
@@ -206,3 +206,38 @@ testHelpers.dev.devOnlyTest("Variable not found warning should suggest correct k
 	Scope.prototype.getPathsForKey = origGetPaths;
 
 });
+
+testHelpers.dev.devOnlyTest("Should warn when the closing tag of a partial does not match the opener", function () {
+	stache.registerPartial('partial', "<div></div>");
+
+	var warningTeardown = testHelpers.dev.willWarn(/bar.stache:1: unexpected closing tag {{\/partiall}} expected {{\/partial}}/);
+
+	stache('bar.stache', '<div>{{<partial}}{{/partiall}}</div>')({
+		name: 'app',
+		user: {}
+	});
+
+	QUnit.equal(warningTeardown(), 1, 'got expected warning');
+});
+
+testHelpers.dev.devOnlyTest("Should warn when the closing tag of a helper does not match the opener", function () {
+	var warningTeardown = testHelpers.dev.willWarn(/bar.stache:1: unexpected closing tag {{\/ify}} expected {{\/if}}/);
+
+	stache('bar.stache', '<div>{{#if}}{{/ify}}</div>')({
+		name: 'app',
+		user: {}
+	});
+
+	QUnit.equal(warningTeardown(), 1, 'got expected warning');
+});
+
+testHelpers.dev.devOnlyTest("Should warn when the closing tag of an inverse  does not match the opener", function () {
+	var warningTeardown = testHelpers.dev.willWarn(/bar.stache:1: unexpected closing tag {{\/Inversey}} expected {{\/Inverse}}/);
+
+	stache('bar.stache', '<div>{{^ Inverse(something)}}{{/Inversey}}</div>')({
+		name: 'app',
+		user: {}
+	});
+
+	QUnit.equal(warningTeardown(), 1, 'got expected warning');
+});


### PR DESCRIPTION
…the stache value if there is no formal way of getting closing tag

I'm not certain this is the way we want to approach this problem, but it seems like an appropriate fallback nonetheless. In the cases where a section is being created without going through a standard "typed" constructor -this includes native helpers as well as partials and such, the renderer will not have a way of getting the closingTag.

Perhaps we want to create some base level "closingTag" functionality as a fallback for all renderers?

Let me know what we think.