### PR TITLE
add Attribute values without quotes to unsupported places

### DIFF
--- a/docs/stache.md
+++ b/docs/stache.md
@@ -1100,6 +1100,12 @@ The following places are not supported:
   <div {{attributeName}}="selected"></div>
   <div {{#magic}}class="{{/magic}}selected"></div>
   ```
+- Attribute values without quotes:
+  ```html
+  <div attribute={{#magic}}"foo"{{/magic}}></div>
+  <div key:raw={{#magic}}"foo"{{/magic}}></div>
+  <div key:from={{#magic}}{{foo}}{{/magic}}></div>
+  ```
 
 ### Expression types
 


### PR DESCRIPTION
Related to #630 

### The changes:
This adds Attribute values without quotes without quotes to unsupported places list, example:
``` <div attribute={{#magic}}"foo"{{/magic}}></div>``` is not supported