### PR TITLE
Add the done.keepNode symbol to portaled nodes

### DIFF
--- a/helpers/-portal-test.js
+++ b/helpers/-portal-test.js
@@ -4,6 +4,7 @@ var DefineMap = require("can-define/map/map");
 var globals = require("can-globals");
 var domMutate = require("can-dom-mutate");
 var domMutateNode = require("can-dom-mutate/node");
+var canSymbol = require("can-symbol");
 
 require("./-portal");
 
@@ -95,4 +96,17 @@ test("Doesn't mess with existing DOM", function() {
 	template(vm);
 	equal(el.firstChild.nodeValue, "Hello", "existing content left alone");
 	equal(el.firstChild.nextSibling.nodeValue, "Matthew");
+});
+
+test("Adds the done.keepNode symbol to nodes", function() {
+	var el = document.createElement("div");
+	var template = stache("{{#portal(root)}}<span>one</span><div>two</div>{{/portal}}");
+	var vm = new DefineMap({ root: el });
+	template(vm);
+
+	var child = el.firstChild;
+	do {
+		ok(child[canSymbol.for("done.keepNode")], "symbol added to this node");
+		child = child.nextSibling;
+	} while(child);
 });

--- a/helpers/-portal.js
+++ b/helpers/-portal.js
@@ -5,14 +5,25 @@ var Observation = require("can-observation");
 var getDocument = require("can-globals/document/document");
 var domMutate = require("can-dom-mutate");
 var domMutateNode = require("can-dom-mutate/node");
+var canSymbol = require("can-symbol");
+
+var keepNodeSymbol = canSymbol.for("done.keepNode");
 
 function portalHelper(elementObservable, options){
 	function evaluator() {
-		return options.fn(
+		var frag = options.fn(
 			options.scope
 			.addLetContext({}),
 			options.options
 		);
+
+		var child = frag.firstChild;
+		while(child) {
+			child[keepNodeSymbol] = true;
+			child = child.nextSibling;
+		}
+
+		return frag;
 	}
 
 	var el, nodeList;


### PR DESCRIPTION
done-autorender, as part of reattachment, removes all nodes within the
`<head>` and `<body>` and replaces it with what was rendered from the
template.

This is a problem for portals which renders outside of the template. The
solution here is to add a symbol to these nodes, which done-autorender
will look for in order to know to leave them alone.

This is part of https://github.com/donejs/donejs/issues/1163