### PR TITLE
Always mark the portal helper as rendered

### DIFF
--- a/helpers/-portal-test.js
+++ b/helpers/-portal-test.js
@@ -110,3 +110,32 @@ test("Adds the done.keepNode symbol to nodes", function() {
 		child = child.nextSibling;
 	} while(child);
 });
+
+test("Doesn't do anything if there isn't a place to put the content", function() {
+	var el = document.createElement("div");
+	var view = stache("{{#portal(root)}}<span>two</span>{{/portal}}");
+	var vm = new DefineMap({ root: null });
+	var frag = view(vm);
+
+	console.log(frag.firstChild, el.firstChild);
+
+	QUnit.equal(frag.firstChild.nodeType, 8, "Only rendered the comment node");
+});
+
+test("Dynamic content outside portal", function() {
+	var view = stache("{{#portal(root)}}<span>two</span>{{/portal}}<div>{{#if(showThing)}}<span>one</span>{{/if}}</div>");
+	var vm = new DefineMap({ showThing: false, root: null });
+	var frag = view(vm);
+
+	var div = frag.firstChild.nextSibling;
+
+	QUnit.equal(div.firstChild.firstChild, null, "nothing rendered in the div yet");
+
+	// Flip the conditional
+	vm.showThing = true;
+	QUnit.equal(div.firstChild.firstChild.nodeValue, "one", "shows the template content");
+
+	// Set the element
+	vm.root = div;
+	QUnit.equal(div.firstChild.nextSibling.firstChild.nodeValue, "two", "shows the portaled content");
+});

--- a/helpers/-portal.js
+++ b/helpers/-portal.js
@@ -56,10 +56,11 @@ function portalHelper(elementObservable, options){
 			var observable = new Observation(evaluator, null, {isObservable: false});
 
 			live.html(node, observable, el, nodeList);
-
-			canReflect.onValue(elementObservable, getElementAndRender);
 			domMutate.onNodeRemoval(el, teardown);
+		} else {
+			options.metadata.rendered = true;
 		}
+		canReflect.onValue(elementObservable, getElementAndRender);
 	}
 
 	getElementAndRender();


### PR DESCRIPTION
If you don't call options.fn() stache just runs the inner helper.
However, when there is not an element initially we won't call
options.fn(). To prevent stache from calling the inner template, setting
`options.metadata.rendered = true`.