### PR TITLE
builtIn types should not warn about safe string

### DIFF
--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -381,7 +381,7 @@ var core = {
 				else if(state.text && !valueShouldBeInsertedAsHTML(value)) {
 					//!steal-remove-start
 					if (process.env.NODE_ENV !== 'production') {
-						if(value !== null && typeof value === "object") {
+						if(value !== null && typeof value === "object" && canReflect.isBuiltIn(value) === false) {
 							dev.warn("Previously, the result of "+
 								expressionString+" in "+state.filename+":"+state.lineNo+
 								", was being inserted as HTML instead of TEXT. Please use stache.safeString(obj) "+

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -6373,10 +6373,10 @@ function makeTest(name, doc, mutation) {
 
 	});
 
-	testHelpers.dev.devOnlyTest("Arrays warn about escaping (#600)", 3, function () {
+	testHelpers.dev.devOnlyTest(" (#600)", 3, function () {
 
 		var map = new SimpleMap({
-			foo: ["<p></p>"]
+			foo: new DefineList(["<p></p>"])
 		});
 
 		var teardown = testHelpers.dev.willWarn(/stache.safeString/, function(message, matched) {

--- a/test/warnings-test.js
+++ b/test/warnings-test.js
@@ -219,3 +219,17 @@ testHelpers.dev.devOnlyTest("Should warn when the closing tag of a partial does 
 
 	QUnit.equal(warningTeardown(), 1, 'got expected warning');
 });
+
+testHelpers.dev.devOnlyTest("builtIn types should not warn #613", function () {
+	var VM = DefineMap.extend({
+		date: "any"
+	});
+
+	var vm = new VM({
+		date: new Date()
+	});
+
+	var teardown = testHelpers.dev.willWarn(/Previously, the result of/);
+	stache('<div>{{date}}</div>')(vm);
+	QUnit.equal(teardown(), 0, 'did not get warning');
+});


### PR DESCRIPTION
For #613 

### The expected behavior
When rendering a built in type (e.g: Date), stache shouldn't warn about using `stache.safeString`.

### The changes:
With the use of `canReflect.builtIn` I Check if the rendered object is built in one.