### PR TITLE
built in helpers can be called as nested call expression

### DIFF
--- a/helpers/core.js
+++ b/helpers/core.js
@@ -210,11 +210,11 @@ var ifHelper = assign(function ifHelper(expr, options) {
 		value = !! helpersCore.resolve(expr);
 	}
 
-	if (value) {
-		return options.fn(options.scope || this);
-	} else {
-		return options.inverse(options.scope || this);
+	if (options) {
+		return value ? options.fn(options.scope || this) : options.inverse(options.scope || this);
 	}
+
+	return !!value;
 }, {requiresOptionsArgument: true, isLiveBound: true});
 
 
@@ -490,6 +490,9 @@ var dataHelper = function(attr, value) {
 
 // ## UNLESS HELPER
 var unlessHelper = function (expr, options) {
+	if(!options) {	
+		return !ifHelper.apply(this, [expr]);	
+	}
 	return ifHelper.apply(this, [expr, assign(assign({}, options), {
 		fn: options.inverse,
 		inverse: options.fn

--- a/test/stache-test.js
+++ b/test/stache-test.js
@@ -5518,8 +5518,6 @@ function makeTest(name, doc, mutation) {
 		renderer({ foo: stache("baz") });
 	});
 
-
-
 	test("#unless works with call expressions", function(){
 		var template = stache("{{#unless(foo)}}foo{{else}}bar{{/unless}}");
 		var map = new DefineMap({
@@ -6459,6 +6457,133 @@ function makeTest(name, doc, mutation) {
 		QUnit.equal(innerHTML(div).trim(), '0 - 1');
 	});
 
+	test("#if works with call expressions", function(){
+		var template = stache("{{#if(foo)}}foo{{else}}bar{{/if}}");
+		var map = new DefineMap({
+			foo: true
+		});
+		var div = doc.createElement("div");
+		var frag = template(map);
+
+		div.appendChild(frag);
+		QUnit.equal(innerHTML(div), "foo");
+		map.foo = false;
+		QUnit.equal(innerHTML(div), "bar");
+	});
+
+	test("#if works with nested call expressions", function(){
+
+		var template = stache("{{#and({if(foo)}, if(bar))}}and{{else}}!and{{/and}} {{#or(if(foo), if(bar))}}or{{else}}!or{{/or}}");
+		var map = new DefineMap({
+			foo: true,
+			bar: true
+		});
+		var div = doc.createElement("div");
+		var frag = template(map);
+
+		div.appendChild(frag);
+		QUnit.equal(innerHTML(div), "and or");
+		map.foo = false;
+		QUnit.equal(innerHTML(div), "!and or");
+		map.bar = false;
+		QUnit.equal(innerHTML(div), "!and !or");
+		map.foo = true;
+		QUnit.equal(innerHTML(div), "!and or");
+		map.bar = true;
+		QUnit.equal(innerHTML(div), "and or");
+	});
+
+	test("#unless works with nested call expressions", function(){
+		var template = stache("{{#and(unless(foo), unless(bar))}}and{{else}}!and{{/and}} {{#or(unless(foo), unless(bar))}}or{{else}}!or{{/or}}");
+		var map = new DefineMap({
+			foo: true,
+			bar: true
+		});
+		var div = doc.createElement("div");
+		var frag = template(map);
+
+		div.appendChild(frag);
+		QUnit.equal(innerHTML(div), "!and !or");
+		map.foo = false;
+		QUnit.equal(innerHTML(div), "!and or");
+		map.bar = false;
+		QUnit.equal(innerHTML(div), "and or");
+		map.foo = true;
+		QUnit.equal(innerHTML(div), "!and or");
+		map.bar = true;
+		QUnit.equal(innerHTML(div), "!and !or");
+	});
+
+	test("#eq works with call expressions", function(){
+		var template = stache("{{#eq(foo, true)}}foo{{else}}bar{{/eq}}");
+		var map = new DefineMap({
+			foo: true
+		});
+		var div = doc.createElement("div");
+		var frag = template(map);
+
+		div.appendChild(frag);
+		QUnit.equal(innerHTML(div), "foo");
+		map.foo = false;
+		QUnit.equal(innerHTML(div), "bar");
+	});
+
+	test("#eq works with nested call expressions", function(){
+
+		var template = stache("{{#and(eq(foo, true), eq(bar, true))}}and{{else}}!and{{/and}} {{#or(eq(foo, true), eq(bar, true))}}or{{else}}!or{{/or}}");
+		var map = new DefineMap({
+			foo: true,
+			bar: true
+		});
+		var div = doc.createElement("div");
+		var frag = template(map);
+
+		div.appendChild(frag);
+		QUnit.equal(innerHTML(div), "and or");
+		map.foo = false;
+		QUnit.equal(innerHTML(div), "!and or");
+		map.bar = false;
+		QUnit.equal(innerHTML(div), "!and !or");
+		map.foo = true;
+		QUnit.equal(innerHTML(div), "!and or");
+		map.bar = true;
+		QUnit.equal(innerHTML(div), "and or");
+	});
+
+	test("#is works with call expressions", function(){
+		var template = stache("{{#is(foo, true)}}foo{{else}}bar{{/eq}}");
+		var map = new DefineMap({
+			foo: true
+		});
+		var div = doc.createElement("div");
+		var frag = template(map);
+
+		div.appendChild(frag);
+		QUnit.equal(innerHTML(div), "foo");
+		map.foo = false;
+		QUnit.equal(innerHTML(div), "bar");
+	});
+
+	test("#is works with nested call expressions", function(){
+		var template = stache("{{#and(is(foo, true), is(bar, true))}}and{{else}}!and{{/and}} {{#or(is(foo, true), is(bar, true))}}or{{else}}!or{{/or}}");
+		var map = new DefineMap({
+			foo: true,
+			bar: true
+		});
+		var div = doc.createElement("div");
+		var frag = template(map);
+
+		div.appendChild(frag);
+		QUnit.equal(innerHTML(div), "and or");
+		map.foo = false;
+		QUnit.equal(innerHTML(div), "!and or");
+		map.bar = false;
+		QUnit.equal(innerHTML(div), "!and !or");
+		map.foo = true;
+		QUnit.equal(innerHTML(div), "!and or");
+		map.bar = true;
+		QUnit.equal(innerHTML(div), "and or");
+	});
 	// PUT NEW TESTS RIGHT BEFORE THIS!
 
 }


### PR DESCRIPTION
For #434

This PR replaces this [one](https://github.com/canjs/can-stache/pull/472)
### The problem
Built in helpers can not be called as nested call expression like this example:
```html
{{#and(eq(foo, true), eq(bar, true))}}and{{else}}!and{{/and}}
```
### The changes:
With calling helpers as nested expression the `options` argument will be set to `undefined` in `#if` and `#unless` helpers, to fix this I changed `ifHelper` function to check if `options` is defined to invoke `options.fn` or `options.inverse` function otherwise `ifHelper` returns the `!!value`.

