### PR TITLE
add links for deprecated docs

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -1,6 +1,8 @@
 @page can-stache.scopeAndContext Legacy Scope Behavior
 @parent can-stache/deprecated
 
+@deprecated {4.15.0} Use [can-stache.helpers.let] and [can-stache.helpers.for-of] instead to refer to things up in the scope.
+
 @body
 
 Every part of a stache template is rendered with a

--- a/docs/expressions/helper.md
+++ b/docs/expressions/helper.md
@@ -1,6 +1,8 @@
 @typedef {String} can-stache/expressions/helper Helper Expression
 @parent can-stache/deprecated
 
+@deprecated {4.15.0} Use [can-stache.expression.call] instead.
+
 @signature `method [EXPRESSION...]`
 
 Calls `method` with zero or many arguments where each argument

--- a/docs/helpers/each.md
+++ b/docs/helpers/each.md
@@ -1,6 +1,8 @@
 @function can-stache.helpers.each {{#each(expression)}}
 @parent can-stache/deprecated
 
+@deprecated {4.15.0} Use [can-stache.helpers.for-of] instead.
+
 @signature `{{#each(EXPRESSION)}}FN{{else}}INVERSE{{/each}}`
 
 Render `FN` for each item in `EXPRESSION`’s return value.  If `EXPRESSION`

--- a/docs/helpers/is.md
+++ b/docs/helpers/is.md
@@ -1,6 +1,8 @@
 @function can-stache.helpers.is {{#is(expressions)}}
 @parent can-stache/deprecated
 
+@deprecated {4.15.0} Use [can-stache.helpers.if] instead.
+
 @signature `{{#is([EXPRESSION...])}}FN{{else}}INVERSE{{/is}}`
 
 Render FN if two values are equal, otherwise render INVERSE.

--- a/docs/helpers/registerHelper.md
+++ b/docs/helpers/registerHelper.md
@@ -2,7 +2,7 @@
 @description Register a helper.
 @parent can-stache/deprecated
 
-@deprecated {4.0} Use [can-stache.addLiveHelper] instead.
+@deprecated {4.15.0} Use [can-stache.addLiveHelper] instead.
 
 @signature `stache.registerHelper(name, helper)`
 

--- a/docs/helpers/unless.md
+++ b/docs/helpers/unless.md
@@ -1,6 +1,8 @@
 @function can-stache.helpers.unless {{#unless(expression)}}
 @parent can-stache/deprecated
 
+@deprecated {4.15.0} Use [can-stache.helpers.if] instead.
+
 @signature `{{#unless(EXPRESSION)}}FN{{else}}INVERSE{{/unless}}`
 
 Renders `FN` if `EXPRESSION` is falsey or `INVERSE` if `EXPRESSION`

--- a/docs/helpers/with.md
+++ b/docs/helpers/with.md
@@ -1,6 +1,8 @@
 @function can-stache.helpers.with {{#with(expression)}}
 @parent can-stache/deprecated
 
+@deprecated {4.15.0} Use [can-stache.helpers.let] instead.
+
 Changes the context within a block.
 
 @signature `{{#with(EXPRESSION)}}BLOCK{{/with}}`

--- a/docs/keys/scope.vars.md
+++ b/docs/keys/scope.vars.md
@@ -2,7 +2,7 @@
 @parent can-stache/deprecated
 @description Used to reference variables specific to the template context
 
-@deprecated {4.15.0} Use `{{ let }}` [can-stache.helpers.let]. instead.
+@deprecated {4.15.0} Use `{{ let }}` [can-stache.helpers.let] instead.
 
 @signature `scope.vars`
 

--- a/docs/keys/scope.vars.md
+++ b/docs/keys/scope.vars.md
@@ -2,6 +2,8 @@
 @parent can-stache/deprecated
 @description Used to reference variables specific to the template context
 
+@deprecated {4.15.0} Use `{{ let }}` [can-stache.helpers.let]. instead.
+
 @signature `scope.vars`
 
 A placeholder for a value that is local to the template.

--- a/docs/registerConverter.md
+++ b/docs/registerConverter.md
@@ -2,7 +2,7 @@
 @description Register a helper for bidirectional value conversion.
 @parent can-stache/deprecated
 
-@deprecated {4.0} Use [can-stache.addConverter] instead. It will always be passed
+@deprecated {4.15.0} Use [can-stache.addConverter] instead. It will always be passed
 observables, removing the need for the user to pass values with `~`.
 
 @signature `stache.registerConverter(converterName, getterSetter)`

--- a/docs/registerPartial.md
+++ b/docs/registerPartial.md
@@ -2,6 +2,8 @@
 @description Register a partial template that can be rendered with [can-stache.tags.partial].
 @parent can-stache/deprecated
 
+@deprecated {4.0} Use ViewModel functions instead.
+
 @signature `stache.registerPartial(name, template)`
 
 Registers a template so it can be rendered with `{{>name}}`.

--- a/docs/tags/partial.md
+++ b/docs/tags/partial.md
@@ -1,6 +1,8 @@
 @function can-stache.tags.partial {{>key}}
 @parent can-stache/deprecated
 
+@deprecated {4.15} Use passing renderer functions through the ViewModel instead.
+
 Render another template within the current template.
 
 @signature `{{>key [EXPRESSION]}}`

--- a/docs/tags/partial.md
+++ b/docs/tags/partial.md
@@ -1,7 +1,7 @@
 @function can-stache.tags.partial {{>key}}
 @parent can-stache/deprecated
 
-@deprecated {4.15} Use passing renderer functions through the ViewModel instead.
+@deprecated {4.15} Pass renderer functions through the ViewModel instead. See the “Calling views” section in the [can-stache#BasicUse can-stache docs] for an example.
 
 Render another template within the current template.
 


### PR DESCRIPTION
For https://github.com/canjs/canjs/issues/4709

This adds `@deprecated` message on the pages for deprecated feature and and links to what should be used instead.

If you find that missed something in the message or add put wrong version, please let me know.