### PR TITLE
Fix memory leak in portal helper

### DIFF
--- a/benchmark/portal-mem.html
+++ b/benchmark/portal-mem.html
@@ -1,0 +1,34 @@
+<button type="button">Run</button>
+
+<script src="../node_modules/steal/steal.js"></script>
+<script type="steal-module">
+	var stache = require("can-stache");
+	var globals = require("can-globals");
+	var domMutate = require("can-dom-mutate");
+	var domMutateNode = require("can-dom-mutate/node");
+	var DefineMap = require("can-define/map/map");
+
+	function run() {
+		var doc = document.implementation.createHTMLDocument("test");
+		globals.setKeyValue("document", doc);
+
+		var el = doc.createElement("div");
+		domMutateNode.appendChild.call(doc.body, el);
+
+		var template = stache("{{#portal(root)}}{{name}}{{/}}");
+		var vm = new DefineMap({name: "Matthew", root: el});
+
+		template(vm);
+
+		var stop = domMutate.onNodeRemoval(el, function() {
+			stop();
+			console.log("Removed");
+		});
+
+		domMutateNode.removeChild.call(doc.body, el);
+	}
+
+	document.querySelector('button').addEventListener('click', () => {
+		run();
+	});
+</script>

--- a/helpers/-portal.js
+++ b/helpers/-portal.js
@@ -26,9 +26,15 @@ function portalHelper(elementObservable, options){
 		return frag;
 	}
 
-	var el, nodeList;
+	var el, nodeList, removeNodeRemovalListener;
 	function teardown() {
 		var root = el;
+
+		if(removeNodeRemovalListener) {
+			removeNodeRemovalListener();
+			removeNodeRemovalListener = null;
+		}
+
 		if(el) {
 			canReflect.offValue(elementObservable, getElementAndRender);
 			el = null;
@@ -61,7 +67,7 @@ function portalHelper(elementObservable, options){
 			var observable = new Observation(evaluator, null, {isObservable: false});
 
 			live.html(node, observable, el, nodeList);
-			domMutate.onNodeRemoval(el, teardown);
+			removeNodeRemovalListener = domMutate.onNodeRemoval(el, teardown);
 		} else {
 			options.metadata.rendered = true;
 		}


### PR DESCRIPTION
This fixes the memory leak in the portal helper. The problem was that we
were never unregistering the call to `domMutate.onNodeRemoval` so there
was always a pointer to the MutationObserver that is observing the
document.

This adds a page in `benchmark/portal-mem.html` that can be used to find
memory leaks.

Fixes #684

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
