### PR TITLE
Warn when closing magic tag is missed

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -476,7 +476,22 @@ function stache (filename, template) {
 				comment: text
 			});
 		},
-		done: function(lineNo){}
+		done: function(lineNo){
+			//!steal-remove-start
+			// warn if closing magic tag is missed #675
+			if (process.env.NODE_ENV !== 'production') {
+				var last = state.sectionElementStack[state.sectionElementStack.length - 1];
+				if (last && last.tag && last.type === "section") {
+					if (filename) {
+						dev.warn(filename + ":" + lineNo + ": closing tag {{/" + last.tag + "}} was expected");
+					}
+					else {
+						dev.warn(lineNo + ": closing tag {{/" + last.tag + "}} was expected");
+					}
+				}
+			}
+			//!steal-remove-end
+		}
 	});
 
 	var renderer = section.compile();

--- a/test/warnings-test.js
+++ b/test/warnings-test.js
@@ -227,3 +227,9 @@ testHelpers.dev.devOnlyTest("Should give a warning when a partial is not found #
 	template();
 	QUnit.equal(teardown(), 1, "got expected warning");
 });
+
+testHelpers.dev.devOnlyTest("Warn on missmatch closing tag ", function () {
+	var warningTeardown = testHelpers.dev.willWarn("missmatch.stache:1: closing tag {{/let}} was expected");
+	stache('missmatch.stache', "{{#let foo='bar'}} {{foo}}")();
+	QUnit.equal(warningTeardown(), 1, "got expected warning");
+});


### PR DESCRIPTION
> This replaces #678 PR

This adds warning when a closing magic tag is missed for example the following triggers a warning:
`{{# let foo="bar"}} {{foo}}`

### The changes:
The warning is added to [done](https://github.com/canjs/can-stache/blob/83191d3c312845acc70f103d167ef378625284ca/can-stache.js#L479) function

Fixes #675