### PR TITLE
698 key has dot

### DIFF
--- a/helpers/-for-of-test.js
+++ b/helpers/-for-of-test.js
@@ -172,3 +172,16 @@ QUnit.test("forOf works after calling helpersCore.__resetHelpers", function(asse
 
 	assert.deepEqual(order, [11,12,13,134234]);
 });
+
+QUnit.test("for(value of object) works if value is keyed with a dot (issue#698)", function(assert){
+	var template = stache("<div class='{{#for(value of object)}}[{{scope.key}}-{{value}}]{{/for}}'></div>");
+	var object = {
+		first: "FIRST",
+		"second.key.has.dot": "SECOND"
+	};
+	var frag = template({
+		object: object
+	});
+
+	assert.equal( frag.firstChild.className, "[first-FIRST][second.key.has.dot-SECOND]");
+});

--- a/helpers/-for-of.js
+++ b/helpers/-for-of.js
@@ -17,7 +17,7 @@ var bindAndRead = function (value) {
 function forOfObject(object, variableName, options){
 	var result = [];
 	canReflect.each(object, function(val, key){
-		// var value = new KeyObservable(object, key);
+		// Allow key to contain a dot, for example: "My.key.has.dot"
 		var value = new KeyObservable(object, key.replace(/\./g, "\\."));
 		var variableScope = {};
 		if(variableName !== undefined){

--- a/helpers/-for-of.js
+++ b/helpers/-for-of.js
@@ -17,7 +17,8 @@ var bindAndRead = function (value) {
 function forOfObject(object, variableName, options){
 	var result = [];
 	canReflect.each(object, function(val, key){
-		var value = new KeyObservable(object, key);
+		// var value = new KeyObservable(object, key);
+		var value = new KeyObservable(object, key.replace(/\./g, "\\."));
 		var variableScope = {};
 		if(variableName !== undefined){
 			variableScope[variableName] = value;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
This fixes an issue where the key in a `for-of` loop contains a dot, for example, if the data looks like this:
```
"Page.2" : {
  pageName: "Page.2"
}
```
`can-stache` could not read/render `item.pageName` where `item` is the object above. Now the dot or dots are escaped which allows the value to be read and rendered.

Closes #698 