### PR TITLE
change to check if the scope already has a let scope before adding one

### DIFF
--- a/can-stache.js
+++ b/can-stache.js
@@ -543,7 +543,12 @@ function stache (filename, template) {
 			scope._parent = templateContextScope;
 		}
 
-		return renderer(scope.addLetContext(), nodeList);
+		// add let context if passed scope doesn't already have one
+		if (!scope.getScope(function(s) {return s._meta.variable === true;})) {
+			scope = scope.addLetContext();
+		}
+
+		return renderer(scope, nodeList);
 	});
 
 	// Identify is a view type


### PR DESCRIPTION
Pushed this after discussion with Justin, but upon reflection, I don't we can make this change. Whenever a template is rendered a new LetContext probably _should_ be added.

The only case where we might be able to avoid this is when the "leaf" context is already a LetContext, but even then, we can't be sure that we shouldn't be adding another one. I think it's probably preferable to have an extra LetContext than not adding one when we should be.

Putting this PR up for further discussion.