### PR TITLE
Add for(integerVal) counting loops

### DIFF
--- a/docs/helpers/for-of.md
+++ b/docs/helpers/for-of.md
@@ -42,24 +42,50 @@
   import {stache} from "can";
 
   var view = stache(`
-  	<ul>
-  		{{# for(name of this.values) }}
-  			<li>{{scope.key}}: {{ name }}</li>
-  		{{/ for }}
-  	</ul>
+    <ul>
+      {{# for(name of this.values) }}
+        <li>{{scope.key}}: {{ name }}</li>
+      {{/ for }}
+    </ul>
   `);
 
   var data = {
-  	values: {
-		first: "Hope",
-		middle: "van",
-		last: "Dyne"
-	}
+    values: {
+    first: "Hope",
+    middle: "van",
+    last: "Dyne"
+  }
   };
 
   var frag = view(data);
   console.log(frag.firstElementChild.innerHTML)
   //-> <li>first: Hope</li><li>middle: van</li><li>last: Dyne</li>
+
+  document.body.appendChild(frag);
+  ```
+  @codepen
+
+  If a positive integer value is passed, it will loop that number of times.
+  You can access the current index with `scope.index`:
+
+  ```js
+  import {stache} from "can";
+
+  var view = stache(`
+    <ul>
+      {{# for(ittr of this.integerValue) }}
+        <li>{{scope.index}}: {{ ittr }}</li>
+      {{/ for }}
+    </ul>
+  `);
+
+  var data = {
+    integerValue: 3
+  };
+
+  var frag = view(data);
+  console.log(frag.firstElementChild.innerHTML)
+  //-> <li>0: 0</li><li>1: 1</li><li>2: 2</li>
 
   document.body.appendChild(frag);
   ```

--- a/docs/helpers/for-of.md
+++ b/docs/helpers/for-of.md
@@ -73,8 +73,8 @@
 
   var view = stache(`
     <ul>
-      {{# for(ittr of this.integerValue) }}
-        <li>{{scope.index}}: {{ ittr }}</li>
+      {{# for(this.integerValue) }}
+        <li>{{scope.index}}</li>
       {{/ for }}
     </ul>
   `);
@@ -85,7 +85,7 @@
 
   var frag = view(data);
   console.log(frag.firstElementChild.innerHTML)
-  //-> <li>0: 0</li><li>1: 1</li><li>2: 2</li>
+  //-> <li>0</li><li>1</li><li>2</li>
 
   document.body.appendChild(frag);
   ```
@@ -128,12 +128,15 @@
   {{/ for }}
   ```
 
-  @param {can-stache/expressions/key-lookup|can-stache/expressions/call} EXPRESSION An
-  expression that typically returns a [can-reflect.isListLike list like] data structure.
-  If the value of the `EXPRESSION` is an observable list (for example: [can-define/list/list]), the resulting HTML is updated when the list changes. When a change in the list happens, only the minimum amount of DOM
-  element changes occur.  The list itself can also change, and a [can-diff/list/list difference]
-  will be performed, which also will perform a minimal set of updates.
+  @param {can-stache/expressions/key-lookup|can-stache/expressions/call} EXPRESSION An expression that returns
 
+
+  - A [can-reflect.isListLike list like] data structure.
+  - An object-like (key-value) data structure.
+  - A positive integer Number
+
+
+  If the value of the `EXPRESSION` is an observable list ([can-define/list/list]) or map ([can-define/map/map]) and an item within it changes, only the minimum amount of DOM elements in the resulting HTML will change. If the list/map/or number value itself changes, a [can-diff/list/list difference] will be performed, resulting again in a minimal set of updates.
 
 
   @param {can-stache.sectionRenderer} FN A subsection that is

--- a/docs/helpers/for-of.md
+++ b/docs/helpers/for-of.md
@@ -42,19 +42,19 @@
   import {stache} from "can";
 
   var view = stache(`
-    <ul>
-      {{# for(name of this.values) }}
-        <li>{{scope.key}}: {{ name }}</li>
-      {{/ for }}
-    </ul>
+  	<ul>
+  		{{# for(name of this.values) }}
+  			<li>{{scope.key}}: {{ name }}</li>
+  		{{/ for }}
+  	</ul>
   `);
 
   var data = {
-    values: {
-    first: "Hope",
-    middle: "van",
-    last: "Dyne"
-  }
+  	values: {
+		first: "Hope",
+		middle: "van",
+		last: "Dyne"
+	}
   };
 
   var frag = view(data);

--- a/helpers/-for-of-test.js
+++ b/helpers/-for-of-test.js
@@ -185,3 +185,31 @@ QUnit.test("for(value of object) works if value is keyed with a dot (issue#698)"
 
 	assert.equal( frag.firstChild.className, "[first-FIRST][second.key.has.dot-SECOND]");
 });
+
+QUnit.test("for(integerValue) works", function (assert) {
+	var template = stache("<div>{{#for(integerValue)}}[{{scope.index}}]{{/for}}</div>");
+	var frag = template({
+		integerValue: 3
+	});
+	assert.equal( frag.firstChild.innerHTML, "[0][1][2]" );
+});
+
+QUnit.test("for(ittr of intVal) works", function (assert) {
+	var template = stache("<div class='{{#for(ittr of object.intVal)}}[{{scope.index}}-{{ittr}}]{{/for}}'></div>");
+	var object = {
+		intVal: 6
+	};
+	var frag = template({
+		object: object
+	});
+
+	assert.equal( frag.firstChild.className, "[0-0][1-1][2-2][3-3][4-4][5-5]" );
+});
+
+QUnit.test("for(integerValue) uses else block for negatives", function (assert) {
+	var template = stache("<div>{{#for(integerValue)}}[{{scope.index}}]{{else}}val is negative{{/for}}</div>");
+	var frag = template({
+		integerValue: -3
+	});
+	assert.equal( frag.firstChild.innerHTML, "val is negative" );
+});

--- a/helpers/-for-of.js
+++ b/helpers/-for-of.js
@@ -16,7 +16,7 @@ var bindAndRead = function (value) {
 
 function forOfInteger(integer, variableName, options) {
 	var result = [];
-  for (var i = 0; i < integer; i++) {
+	for (var i = 0; i < integer; i++) {
 		var variableScope = {};
 		if(variableName !== undefined){
 			variableScope[variableName] = i;
@@ -26,7 +26,7 @@ function forOfInteger(integer, variableName, options) {
 				.add({ index: i }, { special: true })
 				.addLetContext(variableScope) )
 		);
-  }
+	}
 
 	return options.stringOnly ? result.join('') : result;
 }

--- a/helpers/-for-of.js
+++ b/helpers/-for-of.js
@@ -14,6 +14,23 @@ var bindAndRead = function (value) {
 	}
 };
 
+function forOfInteger(integer, variableName, options) {
+	var result = [];
+  for (var i = 0; i < integer; i++) {
+		var variableScope = {};
+		if(variableName !== undefined){
+			variableScope[variableName] = i;
+		}
+		result.push(
+			options.fn( options.scope
+				.add({ index: i }, { special: true })
+				.addLetContext(variableScope) )
+		);
+  }
+
+	return options.stringOnly ? result.join('') : result;
+}
+
 function forOfObject(object, variableName, options){
 	var result = [];
 	canReflect.each(object, function(val, key){
@@ -68,6 +85,9 @@ var forHelper = function(helperOptions) {
 		options = args.pop(),
 		resolved = bindAndRead(items);
 
+	if(resolved && resolved === Math.floor(resolved)) {
+		return forOfInteger(resolved, variableName, helperOptions);
+	}
 	if(resolved && !canReflect.isListLike(resolved)) {
 		return forOfObject(resolved,variableName, helperOptions);
 	}


### PR DESCRIPTION
Hey fam!

This adds integer count loops to output based on numbers.
Most frequently for me I've needed this for heavy visual builds.

```js
	var template = stache("<div>{{#for(integerValue)}}[{{scope.index}}]{{/for}}</div>");
	var frag = template({
		integerValue: 3
	});
	// frag.firstChild.innerHTML === "[0][1][2]"
```

I queried about this years ago, wish I would have taken a look sooner since it was so easy to implement.

I understand if you decide against the feature, but I'd really like to have it and would be happy to discuss further if needed!

Hope you're all well!
//James