### PR TITLE
Named Partials render string result in stringOnly state

### DIFF
--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -289,8 +289,13 @@ var core = {
 				res = evaluator();
 			}
 
-
-			return res == null ? "" : ""+res;
+			if (res == null) {
+				return "";
+			}
+			if (res instanceof DocumentFragment) {
+				return res.textContent;
+			}
+			return ""+res;
 		};
 
 		branchRenderer.exprData = exprData;

--- a/src/mustache_core.js
+++ b/src/mustache_core.js
@@ -292,10 +292,7 @@ var core = {
 			if (res == null) {
 				return "";
 			}
-			if (res instanceof DocumentFragment) {
-				return res.textContent;
-			}
-			return ""+res;
+			return res.nodeType === 11 ? res.textContent : ""+res;
 		};
 
 		branchRenderer.exprData = exprData;

--- a/test/partials-test.js
+++ b/test/partials-test.js
@@ -611,5 +611,5 @@ QUnit.test("Named Partials render string result in stringOnly state", function(a
 	);
 
 	var fragment = view();
-	assert.equal(fragment.firstChild.innerHTML, '.someClass { color: #000; }', "Parial text is rendered");
+	assert.equal(fragment.firstChild.innerHTML, '.someClass { color: #000; }', "Partial text is rendered");
 });

--- a/test/partials-test.js
+++ b/test/partials-test.js
@@ -603,3 +603,13 @@ QUnit.test(" call partials stored in LetContext as Call Expressions #649", funct
 
 	assert.equal( stacheTestHelpers.innerHTML( frag.lastChild ), "bar" );
 });
+
+QUnit.test("Named Partials render string result in stringOnly state", function(assert) {
+	var view = stache( 
+		'{{<addressView}}.someClass { color: #000; }{{/addressView}}' +
+		'<style>{{addressView()}}</style>'
+	);
+
+	var fragment = view();
+	assert.equal(fragment.firstChild.innerHTML, '.someClass { color: #000; }', "Parial text is rendered");
+});


### PR DESCRIPTION
Fixes #710 

### The changes:
The logic changes are in this line
https://github.com/canjs/can-stache/blob/b530682034cf1e59285046df5475b57ce5e5b0b1/src/mustache_core.js#L293

- Check if the returning result of `branchRenderer` is a `DocumentFragment`  instance, in this case return the `textContent` of this result,  `""+res` doesn't cast `DocumentFragment` instance to string.
